### PR TITLE
feat: implement create new project feature

### DIFF
--- a/app/components/hub/CreateNewProjectDialog.tsx
+++ b/app/components/hub/CreateNewProjectDialog.tsx
@@ -1,0 +1,183 @@
+import { Dialog, DialogClose, DialogRoot, DialogTitle, DialogDescription } from '~/components/ui/Dialog';
+import { Button } from '~/components/ui/Button';
+import { Input } from '~/components/ui/Input';
+import { Label } from '~/components/ui/Label';
+import { useState } from 'react';
+import { classNames } from '~/utils/classNames';
+import { toast } from 'react-toastify';
+
+// Define the shape of the successful API response
+interface NewRepoResponse {
+  clone_url: string;
+  full_name: string;
+}
+
+// Define a basic shape for a potential backend error response
+interface ErrorResponse {
+  details?: string;
+}
+
+interface CreateNewProjectDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function CreateNewProjectDialog({ isOpen, onClose }: CreateNewProjectDialogProps) {
+  const [repoName, setRepoName] = useState('');
+  const [description, setDescription] = useState('');
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCreate = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/github-create-repo', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          repoName,
+          description,
+          isPrivate,
+        }),
+      });
+
+      if (!response.ok) {
+        // FIX 2: Add a type assertion for the error data.
+        const errorData = (await response.json()) as ErrorResponse;
+        throw new Error(errorData.details || 'Failed to create repository');
+      }
+
+      const newRepo = (await response.json()) as NewRepoResponse;
+      toast.success(`Successfully created repository ${newRepo.full_name}! Cloning...`);
+      sessionStorage.setItem('projects-need-refresh', 'true');
+
+      onClose();
+
+      if (newRepo.clone_url) {
+        const chatUrl = `/chat?clone=${encodeURIComponent(newRepo.clone_url)}&repo=${encodeURIComponent(repoName)}&fullName=${encodeURIComponent(newRepo.full_name)}&provider=github&from=hub`;
+        window.location.href = chatUrl;
+      } else {
+        throw new Error('Could not find a clone URL in the API response.');
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'An unknown error occurred.';
+      setError(errorMessage);
+      toast.error(`Error: ${errorMessage}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <DialogRoot open={isOpen} onOpenChange={onClose}>
+      <Dialog showCloseButton={true} onClose={onClose}>
+        <div className="p-6">
+          <DialogTitle>
+            <div className="i-ph:github-logo w-6 h-6" />
+            Create New Project
+          </DialogTitle>
+          <DialogDescription>Create a new GitHub repository under your account.</DialogDescription>
+        </div>
+
+        <div className="px-6 pb-6 space-y-6">
+          {/* ... The rest of your JSX remains the same ... */}
+          <div className="space-y-2">
+            <Label htmlFor="repo-name" className="text-gitmesh-elements-textPrimary">
+              Repository Name
+            </Label>
+            <Input
+              id="repo-name"
+              value={repoName}
+              onChange={(e) => setRepoName(e.target.value)}
+              placeholder="my-awesome-project"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="description" className="text-gitmesh-elements-textPrimary">
+              Description
+            </Label>
+            <Input
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="A short description of your project."
+            />
+          </div>
+          <div className="space-y-3">
+            <Label className="text-gitmesh-elements-textPrimary">Visibility</Label>
+            <div className="grid grid-cols-2 gap-4">
+              <div
+                className={classNames(
+                  'p-4 rounded-lg border cursor-pointer transition-all',
+                  !isPrivate
+                    ? 'bg-blue-500/10 border-blue-500'
+                    : 'border-gitmesh-elements-borderColor hover:bg-blue-500/5',
+                )}
+                onClick={() => setIsPrivate(false)}
+              >
+                <div className="flex items-center gap-3">
+                  <div className="i-ph:globe-duotone w-5 h-5 text-blue-500" />
+                  <div>
+                    <p className="font-medium text-gitmesh-elements-textPrimary">Public</p>
+                    <p className="text-sm text-gitmesh-elements-textSecondary">
+                      Anyone on the internet can see this repository.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                className={classNames(
+                  'p-4 rounded-lg border cursor-pointer transition-all',
+                  isPrivate
+                    ? 'bg-blue-500/10 border-blue-500'
+                    : 'border-gitmesh-elements-borderColor hover:bg-blue-500/5',
+                )}
+                onClick={() => setIsPrivate(true)}
+              >
+                <div className="flex items-center gap-3">
+                  <div className="i-ph:lock-duotone w-5 h-5 text-blue-500" />
+                  <div>
+                    <p className="font-medium text-gitmesh-elements-textPrimary">Private</p>
+                    <p className="text-sm text-gitmesh-elements-textSecondary">
+                      You choose who can see and commit to this repository.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          {error && (
+            <div className="p-3 rounded-lg bg-red-50 border border-red-200 dark:bg-red-900/20 dark:border-red-700">
+              <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+            </div>
+          )}
+        </div>
+
+        <div className="px-6 py-4 bg-gitmesh-elements-background-depth-1 border-t border-gitmesh-elements-borderColor flex justify-end space-x-2">
+          <DialogClose asChild>
+            <Button variant="outline" disabled={isLoading}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            onClick={handleCreate}
+            disabled={isLoading || !repoName}
+            className="bg-gitmesh-elements-item-backgroundAccent text-gitmesh-elements-item-contentAccent hover:bg-gitmesh-elements-button-primary-backgroundHover"
+          >
+            {isLoading ? (
+              <div className="i-ph:spinner-gap-bold animate-spin w-5 h-5" />
+            ) : (
+              <div className="i-ph:plus-circle-duotone w-5 h-5" />
+            )}
+            <span>{isLoading ? 'Creating...' : 'Create Project'}</span>
+          </Button>
+        </div>
+      </Dialog>
+    </DialogRoot>
+  );
+}

--- a/app/lib/hooks/useGitHubConnection.ts
+++ b/app/lib/hooks/useGitHubConnection.ts
@@ -139,15 +139,18 @@ export function useGitHubConnection(): UseGitHubConnectionReturn {
       };
 
       // Set cookies for API requests
-      Cookies.set('githubToken', token);
-      Cookies.set('githubUsername', userData.login);
+      console.log('Setting cookies for API requests...');
+      Cookies.set('githubToken', token, { path: '/' });
+      Cookies.set('githubUsername', userData.login, { path: '/' });
       Cookies.set(
         'git:github.com',
         JSON.stringify({
           username: token,
           password: 'x-oauth-basic',
         }),
+        { path: '/' },
       );
+      console.log('Cookies have been set.');
 
       // Update the store
       updateGitHubConnection(connectionData);

--- a/app/routes/api.github-create-repo.ts
+++ b/app/routes/api.github-create-repo.ts
@@ -1,0 +1,88 @@
+import { json, type ActionFunctionArgs } from '@remix-run/cloudflare';
+import { withSecurity } from '~/lib/security';
+
+// Define the shape of the incoming request body
+interface CreateRepoRequestBody {
+  repoName?: string;
+  description?: string;
+  isPrivate?: boolean;
+}
+
+// Define a basic shape for a potential GitHub API error
+interface GitHubApiError {
+  message?: string;
+  [key: string]: any; // Allow other properties
+}
+
+// A helper to parse the specific cookie we need
+function getGitHubTokenFromCookie(cookieHeader: string | null): string | null {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const cookies = cookieHeader.split(';').map((c) => c.trim());
+  const cookie = cookies.find((c) => c.startsWith('githubToken='));
+
+  return cookie ? cookie.split('=')[1] : null;
+}
+
+async function createRepoAction({ request, context: _context }: ActionFunctionArgs) {
+  try {
+    const cookieHeader = request.headers.get('Cookie');
+    const githubToken = getGitHubTokenFromCookie(cookieHeader);
+
+    if (!githubToken) {
+      return json({ error: 'GitHub token not found in cookies' }, { status: 401 });
+    }
+
+    const { repoName, description, isPrivate } = (await request.json()) as CreateRepoRequestBody;
+
+    if (!repoName) {
+      return json({ error: 'Repository name is required' }, { status: 400 });
+    }
+
+    const response = await fetch('https://api.github.com/user/repos', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github.v3+json',
+        Authorization: `token ${githubToken}`,
+        'User-Agent': 'gitmesh-app',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: repoName,
+        description,
+        private: isPrivate,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = (await response.json()) as GitHubApiError;
+      // Keep this server-side log for production error monitoring
+      console.error('GitHub API Error during repo creation:', errorData);
+
+      return json(
+        { error: 'Failed to create repository on GitHub', details: errorData.message || 'Unknown error' },
+        { status: response.status },
+      );
+    }
+
+    const newRepo = await response.json();
+
+    return json(newRepo, { status: 201 });
+  } catch (error) {
+    console.error('Error creating GitHub repository:', error);
+    return json(
+      {
+        error: 'An unexpected error occurred',
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export const action = withSecurity(createRepoAction, {
+  rateLimit: true,
+  allowedMethods: ['POST'],
+});


### PR DESCRIPTION
Solved issue : #99 
The user can now initiate a "Create New Project" action, provide a name, description, and visibility, and the repository will be created on their GitHub account and automatically opened within the GitMesh chat and editor, ready for development.

### Changes made
- Added "Create New Project" Button - Created a button in "Projects" page that initiates the creation of a new project under user's GitHub account.
- New Frontend Component: Added a CreateNewProjectDialog.tsx component, which provides a clean and intuitive form for users to input their new repository's details.
- New Backend API Endpoint: Created a new API route at /api/github-create-repo that securely handles the creation of a new repository using the user's authenticated GitHub PAT.
- Improved Navigation: After creating a new repository, user is now automatically redirected to the chat view for that project.
- Automatic Refresh: The project list on the hub page now automatically refreshes after you create a new project, so you no longer need to manually refresh the page to see your new repository.

### Testing
This feature was manually tested end-to-end:

1. Verified that the "Create New Project" dialog opens and functions correctly.
2. Confirmed that submitting the form successfully creates a new repository (both public and private) on the connected GitHub account.
3. Validated that upon successful creation, the application correctly clones the new repository and automatically navigates to the new chat session.
4. Tested error handling for cases like existing repository names and invalid authentication tokens.