### PR TITLE
bug fix: fix chat page content shift when sidebar expands

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -377,7 +377,6 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
               styles.Chat,
               'flex flex-col flex-grow lg:min-w-[var(--chat-min-width)] h-full overflow-y-auto transition-all duration-200',
               {
-                'ml-[340px]': isSidebarOpen,
                 'ml-0': !isSidebarOpen,
               },
             )}
@@ -510,10 +509,8 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
             {chatStarted && (
               <div
                 className={classNames('fixed bottom-4 z-50 transition-all duration-200', {
-                  'left-[340px] right-[var(--workbench-width)]': showWorkbench && isSidebarOpen,
-                  'left-0 right-[var(--workbench-width)]': showWorkbench && !isSidebarOpen,
-                  'left-[340px] right-0': !showWorkbench && isSidebarOpen,
-                  'left-0 right-0': !showWorkbench && !isSidebarOpen,
+                  'left-0 right-[var(--workbench-width)]': showWorkbench,
+                  'left-0 right-0': !showWorkbench,
                 })}
               >
                 <div

--- a/app/components/header/Header.tsx
+++ b/app/components/header/Header.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@nanostores/react';
 import { ClientOnly } from 'remix-utils/client-only';
 import { chatStore } from '~/lib/stores/chat';
+import { sidebarOpen } from '~/lib/stores/sidebar';
 import { classNames } from '~/utils/classNames';
 import { HeaderActionButtons } from './HeaderActionButtons.client';
 import { ChatDescription } from '~/lib/persistence/ChatDescription.client';
@@ -8,6 +9,7 @@ import { RepoStatus } from '~/components/chat/RepoStatus';
 
 export function Header() {
   const chat = useStore(chatStore);
+  const isSidebarOpen = useStore(sidebarOpen);
 
   return (
     <header
@@ -20,7 +22,11 @@ export function Header() {
         },
       )}
     >
-      <div className="flex items-center gap-2 z-logo text-gitmesh-elements-textPrimary cursor-pointer">
+      <div
+        className="flex items-center gap-2 z-logo text-gitmesh-elements-textPrimary cursor-pointer transition-colors hover:text-blue-700 dark:hover:text-blue-300"
+        onClick={() => sidebarOpen.set(!isSidebarOpen)}
+        title={isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+      >
         <div className="i-ph:sidebar-simple-duotone text-xl" />
         {/* <a href="/" className="text-2xl font-semibold text-accent flex items-center">
           <img src="/gitmesh.png" alt="logo" className="w-[90px] inline-block dark:hidden" />

--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -6,7 +6,7 @@ import { ThemeSwitch } from '~/components/ui/ThemeSwitch';
 import { ControlPanel } from '~/components/@settings/core/ControlPanel';
 import { Button } from '~/components/ui/Button';
 import { deleteById, getAll, chatId, type ChatHistoryItem, useChatHistory, openDatabase } from '~/lib/persistence';
-import { cubicEasingFn } from '~/utils/easings';
+
 import { HistoryItem } from './HistoryItem';
 import { binDates } from './date-binning';
 import { useSearchFilter } from '~/lib/hooks/useSearchFilter';
@@ -17,21 +17,23 @@ import { sidebarOpen } from '~/lib/stores/sidebar';
 
 const menuVariants = {
   closed: {
+    x: '-340px',
     opacity: 0,
-    visibility: 'hidden',
-    left: '-340px',
     transition: {
-      duration: 0.2,
-      ease: cubicEasingFn,
+      duration: 0.3,
+      ease: 'easeInOut',
+    },
+    transitionEnd: {
+      visibility: 'hidden',
     },
   },
   open: {
+    x: 0,
     opacity: 1,
     visibility: 'initial',
-    left: 0,
     transition: {
-      duration: 0.2,
-      ease: cubicEasingFn,
+      duration: 0.3,
+      ease: 'easeInOut',
     },
   },
 } satisfies Variants;
@@ -301,31 +303,6 @@ export const Menu = () => {
     }
   }, [open, selectionMode]);
 
-  useEffect(() => {
-    const enterThreshold = 20;
-    const exitThreshold = 20;
-
-    function onMouseMove(event: MouseEvent) {
-      if (isSettingsOpen) {
-        return;
-      }
-
-      if (event.pageX < enterThreshold) {
-        sidebarOpen.set(true);
-      }
-
-      if (menuRef.current && event.clientX > menuRef.current.getBoundingClientRect().right + exitThreshold) {
-        sidebarOpen.set(false);
-      }
-    }
-
-    window.addEventListener('mousemove', onMouseMove);
-
-    return () => {
-      window.removeEventListener('mousemove', onMouseMove);
-    };
-  }, [isSettingsOpen]);
-
   const handleDuplicate = async (id: string) => {
     await duplicateCurrentChat(id);
     loadEntries(); // Reload the list after duplication
@@ -349,7 +326,7 @@ export const Menu = () => {
         variants={menuVariants}
         style={{ width: '340px' }}
         className={classNames(
-          'flex selection-accent flex-col side-menu fixed top-0 h-full rounded-r-2xl',
+          'flex selection-accent flex-col side-menu fixed top-[var(--header-height)] h-[calc(100%_-_var(--header-height))] rounded-r-2xl',
           'bg-white dark:bg-gray-950 border-r border-gitmesh-elements-borderColor',
           'shadow-sm text-sm',
           isSettingsOpen ? 'z-40' : 'z-sidebar',


### PR DESCRIPTION
Solved issue: #110 
The main chat content no longer shifts to the right when sidebar is toggled, improved how the sidebar toggles, fixed the position of sidebar.

### Changes made
- Fixed Content Shifting: The main chat content and the chat input box now remain static when the sidebar is opened or closed, preventing jarring layout shifts.
- Sidebar Repositioning: The sidebar now renders neatly below the fixed header, creating a more organized and intuitive UI structure.
- Manual Sidebar Toggle: The distracting behavior of the sidebar automatically opening on mouse hover has been removed. It is now controlled exclusively by a new toggle button in the header.
