### PR TITLE
UX Improvement: Notifications Accessible via Navbar Bell and removing notifications section from settings

### DIFF
--- a/app/components/@settings/tabs/notifications/NotificationsTab.tsx
+++ b/app/components/@settings/tabs/notifications/NotificationsTab.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { useStore } from '@nanostores/react';
 import { motion } from 'framer-motion';
 import { logStore } from '~/lib/stores/logs';
-import { useStore } from '@nanostores/react';
 import { formatDistanceToNow } from 'date-fns';
 import { classNames } from '~/utils/classNames';
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { Dropdown, DropdownSeparator } from '~/components/ui/Dropdown';
+
+type FilterType = 'all' | 'system' | 'error' | 'warning' | 'update' | 'info' | 'provider' | 'network';
 
 interface NotificationDetails {
   type?: string;
@@ -15,17 +17,15 @@ interface NotificationDetails {
   updateUrl?: string;
 }
 
-type FilterType = 'all' | 'system' | 'error' | 'warning' | 'update' | 'info' | 'provider' | 'network';
-
-const NotificationsTab = () => {
+export function NotificationsTab() {
   const [filter, setFilter] = useState<FilterType>('all');
   const logs = useStore(logStore.logs);
 
   useEffect(() => {
-    const startTime = performance.now();
+    const start = performance.now();
 
     return () => {
-      const duration = performance.now() - startTime;
+      const duration = performance.now() - start;
       logStore.logPerformanceMetric('NotificationsTab', 'mount-duration', duration);
     };
   }, []);
@@ -138,14 +138,11 @@ const NotificationsTab = () => {
           <button
             onClick={() => details.updateUrl && handleUpdateAction(details.updateUrl)}
             className={classNames(
-              'mt-2 inline-flex items-center gap-2',
-              'rounded-lg px-3 py-1.5',
-              'text-sm font-medium',
+              'mt-2 inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium',
               'bg-[#FAFAFA] dark:bg-[#0A0A0A]',
               'border border-[#E5E5E5] dark:border-[#1A1A1A]',
               'text-gray-900 dark:text-white',
-              'hover:bg-blue-500/10 dark:hover:bg-blue-500/20',
-              'transition-all duration-200',
+              'hover:bg-blue-500/10 dark:hover:bg-blue-500/20 transition-all duration-200',
             )}
           >
             <span className="i-ph:git-branch text-lg" />
@@ -159,132 +156,108 @@ const NotificationsTab = () => {
   };
 
   const filterOptions: { id: FilterType; label: string; icon: string; color: string }[] = [
-    { id: 'all', label: 'All Notifications', icon: 'i-ph:bell', color: '#3b82f6' },
+    { id: 'all', label: 'All', icon: 'i-ph:bell', color: '#3b82f6' },
     { id: 'system', label: 'System', icon: 'i-ph:gear', color: '#6b7280' },
     { id: 'update', label: 'Updates', icon: 'i-ph:arrow-circle-up', color: '#3b82f6' },
     { id: 'error', label: 'Errors', icon: 'i-ph:warning-circle', color: '#ef4444' },
     { id: 'warning', label: 'Warnings', icon: 'i-ph:warning', color: '#f59e0b' },
-    { id: 'info', label: 'Information', icon: 'i-ph:info', color: '#3b82f6' },
+    { id: 'info', label: 'Info', icon: 'i-ph:info', color: '#3b82f6' },
     { id: 'provider', label: 'Providers', icon: 'i-ph:robot', color: '#10b981' },
     { id: 'network', label: 'Network', icon: 'i-ph:wifi-high', color: '#6366f1' },
   ];
 
+  const trigger = (
+    <button
+      className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-200 text-gitmesh-elements-textSecondary bg-gitmesh-elements-background-depth-1 hover:text-gitmesh-elements-textPrimary hover:bg-gitmesh-elements-background-depth-2"
+      title="Notifications"
+    >
+      <div className="i-ph:bell-duotone w-6 h-6" />
+      <div className="i-ph:caret-down w-4 h-4" />
+    </button>
+  );
+
   return (
-    <div className="flex h-full flex-col gap-6">
-      <div className="flex items-center justify-between">
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger asChild>
-            <button
-              className={classNames(
-                'flex items-center gap-2',
-                'rounded-lg px-3 py-1.5',
-                'text-sm text-gray-900 dark:text-white',
-                'bg-[#FAFAFA] dark:bg-[#0A0A0A]',
-                'border border-[#E5E5E5] dark:border-[#1A1A1A]',
-                'hover:bg-blue-500/10 dark:hover:bg-blue-500/20',
-                'transition-all duration-200',
-              )}
-            >
-              <span
-                className={classNames('text-lg', filterOptions.find((opt) => opt.id === filter)?.icon || 'i-ph:funnel')}
-                style={{ color: filterOptions.find((opt) => opt.id === filter)?.color }}
-              />
-              {filterOptions.find((opt) => opt.id === filter)?.label || 'Filter Notifications'}
-              <span className="i-ph:caret-down text-lg text-gray-500 dark:text-gray-400" />
-            </button>
-          </DropdownMenu.Trigger>
-
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content
-              className="min-w-[200px] bg-white dark:bg-[#0A0A0A] rounded-lg shadow-lg py-1 z-[250] animate-in fade-in-0 zoom-in-95 border border-[#E5E5E5] dark:border-[#1A1A1A]"
-              sideOffset={5}
-              align="start"
-              side="bottom"
-            >
-              {filterOptions.map((option) => (
-                <DropdownMenu.Item
-                  key={option.id}
-                  className="group flex items-center px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-blue-500/10 dark:hover:bg-blue-500/20 cursor-pointer transition-colors"
-                  onClick={() => handleFilterChange(option.id)}
-                >
-                  <div className="mr-3 flex h-5 w-5 items-center justify-center">
-                    <div
-                      className={classNames(option.icon, 'text-lg group-hover:text-blue-500 transition-colors')}
-                      style={{ color: option.color }}
-                    />
-                  </div>
-                  <span className="group-hover:text-blue-500 transition-colors">{option.label}</span>
-                </DropdownMenu.Item>
-              ))}
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
-
+    <Dropdown trigger={trigger} align="end" sideOffset={8}>
+      {/* Header */}
+      <div className="flex items-center justify-between w-full px-2 py-1">
+        <span className="text-sm font-medium text-gray-900 dark:text-gray-200">Notifications</span>
         <button
           onClick={handleClearNotifications}
           className={classNames(
-            'group flex items-center gap-2',
-            'rounded-lg px-3 py-1.5',
-            'text-sm text-gray-900 dark:text-white',
-            'bg-[#FAFAFA] dark:bg-[#0A0A0A]',
-            'border border-[#E5E5E5] dark:border-[#1A1A1A]',
-            'hover:bg-blue-500/10 dark:hover:bg-blue-500/20',
-            'transition-all duration-200',
+            'flex items-center gap-1 text-xs px-2 py-1 rounded-md font-medium transition-colors',
+            'text-gray-500 hover:text-blue-500 dark:text-gray-300 dark:hover:text-blue-400',
+            'bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700',
           )}
         >
-          <span className="i-ph:trash text-lg text-gray-500 dark:text-gray-400 group-hover:text-blue-500 transition-colors" />
+          <span className="i-ph:trash text-sm" />
           Clear All
         </button>
       </div>
 
-      <div className="flex flex-col gap-4">
+      <DropdownSeparator />
+
+      {/* Filter Buttons */}
+      <div className="flex flex-wrap gap-1 px-2 pb-2">
+        {filterOptions.map((opt) => {
+          const isActive = filter === opt.id;
+
+          return (
+            <button
+              key={opt.id}
+              onClick={() => handleFilterChange(opt.id)}
+              type="button"
+              aria-pressed={isActive}
+              className={classNames(
+                'flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium transition-colors',
+                // Set background based on active state & dark mode
+                isActive
+                  ? 'bg-blue-500/20 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',
+              )}
+            >
+              <span className={classNames(opt.icon, 'text-sm')} />
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <DropdownSeparator />
+
+      {/* Notifications List */}
+      <div className="max-h-[400px] overflow-y-auto px-2 py-1">
         {filteredLogs.length === 0 ? (
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className={classNames(
-              'flex flex-col items-center justify-center gap-4',
-              'rounded-lg p-8 text-center',
-              'bg-[#FAFAFA] dark:bg-[#0A0A0A]',
-              'border border-[#E5E5E5] dark:border-[#1A1A1A]',
-            )}
-          >
-            <span className="i-ph:bell-slash text-4xl text-gray-400 dark:text-gray-600" />
-            <div className="flex flex-col gap-1">
-              <h3 className="text-sm font-medium text-gray-900 dark:text-white">No Notifications</h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400">You're all caught up!</p>
-            </div>
-          </motion.div>
+          <div className="flex flex-col items-center justify-center gap-2 p-4 text-center text-gray-500 dark:text-gray-400">
+            <span className="i-ph:bell-slash text-2xl" />
+            <p className="text-sm">No Notifications</p>
+          </div>
         ) : (
           filteredLogs.map((log) => {
             const style = getNotificationStyle(log.level, log.details?.type);
             return (
               <motion.div
                 key={log.id}
-                initial={{ opacity: 0, y: 20 }}
+                initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 className={classNames(
-                  'flex flex-col gap-2',
-                  'rounded-lg p-4',
-                  'bg-[#FAFAFA] dark:bg-[#0A0A0A]',
-                  'border border-[#E5E5E5] dark:border-[#1A1A1A]',
+                  'flex flex-col gap-1 p-3 mb-1 rounded-lg border border-[#E5E5E5] dark:border-[#1A1A1A] bg-[#FAFAFA] dark:bg-[#0A0A0A]',
                   style.bg,
                   'transition-all duration-200',
                 )}
               >
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex items-start gap-3">
-                    <span className={classNames('text-lg', style.icon, style.color)} />
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex items-start gap-2">
+                    <span className={classNames('text-base', style.icon, style.color)} />
                     <div className="flex flex-col gap-1">
                       <h3 className="text-sm font-medium text-gray-900 dark:text-white">{log.message}</h3>
                       {log.details && renderNotificationDetails(log.details as NotificationDetails)}
                       <p className="text-xs text-gray-500 dark:text-gray-400">
-                        Category: {log.category}
+                        {log.category}
                         {log.subCategory ? ` > ${log.subCategory}` : ''}
                       </p>
                     </div>
                   </div>
-                  <time className="shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                  <time className="text-xs text-gray-500 dark:text-gray-400 shrink-0">
                     {formatDistanceToNow(new Date(log.timestamp), { addSuffix: true })}
                   </time>
                 </div>
@@ -293,8 +266,8 @@ const NotificationsTab = () => {
           })
         )}
       </div>
-    </div>
+    </Dropdown>
   );
-};
+}
 
 export default NotificationsTab;

--- a/app/components/@settings/tabs/providers/local/LocalProvidersTab.tsx
+++ b/app/components/@settings/tabs/providers/local/LocalProvidersTab.tsx
@@ -17,7 +17,7 @@ import ProviderCard from './ProviderCard';
 import ModelCard from './ModelCard';
 import { OLLAMA_API_URL } from './types';
 import type { OllamaModel, LMStudioModel } from './types';
-import { Cpu, Server, BookOpen, Activity, PackageOpen, Monitor, Loader2, RotateCw, ExternalLink } from 'lucide-react';
+import { Server, BookOpen, Activity, PackageOpen, Monitor, Loader2, RotateCw, ExternalLink } from 'lucide-react';
 
 // Type definitions
 type ViewMode = 'dashboard' | 'guide' | 'status';
@@ -316,21 +316,11 @@ export default function LocalProvidersTab() {
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setViewMode('guide')}
-              className="gap-2"
-            >
+            <Button variant="outline" size="sm" onClick={() => setViewMode('guide')} className="gap-2">
               <BookOpen className="w-4 h-4" />
               Setup Guide
             </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setViewMode('status')}
-              className="gap-2"
-            >
+            <Button variant="outline" size="sm" onClick={() => setViewMode('status')} className="gap-2">
               <Activity className="w-4 h-4" />
               Status
             </Button>
@@ -401,12 +391,7 @@ export default function LocalProvidersTab() {
                           </a>{' '}
                           to browse available models
                         </p>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="gap-2"
-                          _asChild
-                        >
+                        <Button variant="outline" size="sm" className="gap-2" _asChild>
                           <a
                             href="https://ollama.com/library"
                             target="_blank"
@@ -475,12 +460,7 @@ export default function LocalProvidersTab() {
                         <p className="text-sm text-gitmesh-elements-textSecondary mb-4">
                           Make sure LM Studio is running with the local server started and CORS enabled.
                         </p>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="gap-2"
-                          _asChild
-                        >
+                        <Button variant="outline" size="sm" className="gap-2" _asChild>
                           <a
                             href="https://lmstudio.ai/"
                             target="_blank"
@@ -495,7 +475,10 @@ export default function LocalProvidersTab() {
                     ) : (
                       <div className="grid gap-4">
                         {lmStudioModels.map((model) => (
-                          <Card key={model.id} className="bg-gitmesh-elements-background-depth-3 border border-gitmesh-elements-borderColor">
+                          <Card
+                            key={model.id}
+                            className="bg-gitmesh-elements-background-depth-3 border border-gitmesh-elements-borderColor"
+                          >
                             <CardContent className="pt-6 px-4 pb-4">
                               <div className="space-y-2">
                                 <div className="flex items-center gap-2">

--- a/app/components/@settings/tabs/providers/local/ProviderCard.tsx
+++ b/app/components/@settings/tabs/providers/local/ProviderCard.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Switch } from '~/components/ui/Switch';
 import { Card, CardContent } from '~/components/ui/Card';
 import { Link, Server, Monitor, Globe } from 'lucide-react';
-import { classNames } from '~/utils/classNames';
 import type { IProviderConfig } from '~/types/model';
 import { PROVIDER_DESCRIPTIONS } from './types';
 

--- a/app/components/@settings/tabs/providers/local/SetupGuide.tsx
+++ b/app/components/@settings/tabs/providers/local/SetupGuide.tsx
@@ -124,12 +124,7 @@ function SetupGuide({ onBack }: { onBack: () => void }) {
                     <Monitor className="w-4 h-4 text-gitmesh-elements-textPrimary" />
                     <strong className="text-gitmesh-elements-textPrimary">macOS</strong>
                   </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="w-full gap-2"
-                    _asChild
-                  >
+                  <Button variant="outline" size="sm" className="w-full gap-2" _asChild>
                     <a
                       href="https://ollama.com/download/mac"
                       target="_blank"
@@ -147,12 +142,7 @@ function SetupGuide({ onBack }: { onBack: () => void }) {
                     <Monitor className="w-4 h-4 text-gitmesh-elements-textPrimary" />
                     <strong className="text-gitmesh-elements-textPrimary">Windows</strong>
                   </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="w-full gap-2"
-                    _asChild
-                  >
+                  <Button variant="outline" size="sm" className="w-full gap-2" _asChild>
                     <a
                       href="https://ollama.com/download/windows"
                       target="_blank"
@@ -372,12 +362,7 @@ function SetupGuide({ onBack }: { onBack: () => void }) {
               <p className="text-sm text-gitmesh-elements-textSecondary mb-3">
                 Download LM Studio for Windows, macOS, or Linux from the official website.
               </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-2"
-                _asChild
-              >
+              <Button variant="outline" size="sm" className="gap-2" _asChild>
                 <a
                   href="https://lmstudio.ai/"
                   target="_blank"

--- a/app/components/@settings/tabs/providers/local/StatusDashboard.tsx
+++ b/app/components/@settings/tabs/providers/local/StatusDashboard.tsx
@@ -42,7 +42,10 @@ function StatusDashboard({ onBack }: { onBack: () => void }) {
       ) : (
         <div className="space-y-4">
           {healthStatuses.map((status) => (
-            <Card key={`${status.provider}-${status.baseUrl}`} className="bg-gitmesh-elements-background-depth-1 border border-gitmesh-elements-borderColor">
+            <Card
+              key={`${status.provider}-${status.baseUrl}`}
+              className="bg-gitmesh-elements-background-depth-1 border border-gitmesh-elements-borderColor"
+            >
               <CardContent className="pt-8 px-6 pb-6">
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-3">

--- a/app/components/hub/HubLayoutSimple.tsx
+++ b/app/components/hub/HubLayoutSimple.tsx
@@ -7,6 +7,7 @@ import BackgroundRays from '~/components/ui/BackgroundRays';
 import { isGitHubConnected } from '~/lib/stores/githubConnection';
 import { isGitLabConnected } from '~/lib/stores/gitlabConnection';
 import { ProfileButton } from './ProfileButton';
+import NotificationsTab from '~/components/@settings/tabs/notifications/NotificationsTab';
 
 interface HubLayoutProps {
   children: React.ReactNode;
@@ -71,6 +72,7 @@ export function HubLayout({ children }: HubLayoutProps) {
                   {item.label}
                 </NavLink>
               ))}
+              <NotificationsTab />
               <ProfileButton />
             </div>
           </div>

--- a/app/components/hub/settings/HubSettingsLayout.tsx
+++ b/app/components/hub/settings/HubSettingsLayout.tsx
@@ -22,12 +22,6 @@ export function HubSettingsLayout({ children }: HubSettingsLayoutProps) {
       description: 'Configure application preferences',
     },
     {
-      to: '/hub/settings/notifications',
-      label: 'Notifications',
-      icon: 'i-ph:bell-duotone',
-      description: 'View and manage your notifications',
-    },
-    {
       to: '/hub/settings/features',
       label: 'Features',
       icon: 'i-ph:star-duotone',

--- a/app/routes/hub.overview.tsx
+++ b/app/routes/hub.overview.tsx
@@ -531,7 +531,6 @@ export default function HubOverview() {
               {[
                 { to: '/hub/settings/profile', icon: 'i-ph:user', label: 'Profile' },
                 { to: '/hub/settings/general', icon: 'i-ph:gear', label: 'Settings' },
-                { to: '/hub/settings/notifications', icon: 'i-ph:bell', label: 'Notifications' },
                 { to: '/hub/settings/features', icon: 'i-ph:star', label: 'Features' },
                 { to: '/hub/settings/data', icon: 'i-ph:database', label: 'Data' },
                 { to: '/hub/settings/cloud-providers', icon: 'i-ph:cloud', label: 'Cloud' },

--- a/app/routes/hub.settings.notifications.tsx
+++ b/app/routes/hub.settings.notifications.tsx
@@ -1,9 +1,0 @@
-import NotificationsTab from '~/components/@settings/tabs/notifications/NotificationsTab';
-
-export default function HubSettingsNotifications() {
-  return (
-    <div className="p-6">
-      <NotificationsTab />
-    </div>
-  );
-}


### PR DESCRIPTION
### Summary
- Removed the misplaced Notifications section from the settings page.
- Added a bell icon in the top navbar, positioned to the left of the profile icon.
- Clicking the bell icon opens a clean dropdown panel displaying notifications in a structured, scrollable list.
---
### Purpose
- Make notifications easily accessible from anywhere in the app.
- Remove clutter from the settings page.
- Ensure consistent UI for dark/light themes, including filter buttons and headers.
---
### Changes Made
- Removed the Notifications section from the Settings page.
- Added a bell icon in the top navbar.
- Dropdown panel supports filtering by type (All, System, Updates, Errors, Warnings, Info, Providers, Network), maintaining existing functionality.
- Updated notification UI to match dark/light themes, including proper background and text colors for filter buttons and headers.
- Preserved performance logging and action handlers for notifications.
- Removed old `/hub/settings/notifications` route.
- Tested in both dark and light themes to ensure consistency.
---
### Screenshots
- **Old Notifications section removed from settings page:**  
<img width="1579" height="864" alt="image" src="https://github.com/user-attachments/assets/06d1198e-974a-41b6-b288-cbe61a1fcd2a" />

- **Notifications Relocated to Navbar:**  
<img width="1592" height="77" alt="image" src="https://github.com/user-attachments/assets/b18e4fc0-8308-4919-93ab-f10210826deb" />

- **Dropdown Functionality & Styling:**  
<img width="817" height="610" alt="image" src="https://github.com/user-attachments/assets/ceb121a5-0cca-4602-9295-793670b71a56" />

<br>
Tested in both color themes
<br>
This solves the issue #107
