### PR TITLE
After fixing the show details button UI in hub/settings/event-log

### DIFF
--- a/app/components/@settings/tabs/event-logs/EventLogsTab.tsx
+++ b/app/components/@settings/tabs/event-logs/EventLogsTab.tsx
@@ -230,7 +230,16 @@ const LogEntryItem = ({ log, isExpanded: forceExpanded, use24Hour, showTimestamp
               <>
                 <button
                   onClick={() => setLocalExpanded(!localExpanded)}
-                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
+                  className="
+    text-xs font-semibold
+    text-gray-800 dark:text-white
+    bg-gray-200 dark:bg-gray-800
+    hover:bg-blue-500 dark:hover:bg-blue-600
+    hover:text-white
+    rounded-md px-3 py-1
+    shadow-sm hover:shadow-md
+    transition-all duration-200 ease-in-out
+  "
                 >
                   {localExpanded ? 'Hide' : 'Show'} Details
                 </button>


### PR DESCRIPTION
**Changes:**
- Converted the button to adapt to both **light** and **dark** themes.
- Added **background colors** for better visibility.
- Improved **hover effect** to provide clear feedback.
- Adjusted **padding and width** for a compact, visually appealing design.
- Added **smooth transitions** for color and shadow changes.
- Ensured **text color** contrasts appropriately with background in both themes.

**Before:**
- Only text was visible.
- No background or theme support.
- Poor visibility in light and dark modes.

**After:**
- Button now has a background and proper text color.
- Compact size with padding and rounded corners for a better UI.
- Smooth transitions and shadow on hover improve UX.

**Testing:**
- Verified button in **light mode** and **dark mode**.
- Checked hover effects and text visibility.
- Ensured toggle functionality (`setLocalExpanded`) works as expected.

<img width="1585" height="458" alt="image" src="https://github.com/user-attachments/assets/af507daf-8223-488e-b370-e548e9cbe75a" />
<img width="1489" height="250" alt="image" src="https://github.com/user-attachments/assets/546b6aa7-fb37-4730-948f-04a5872e8326" />

In dark theme
<img width="1512" height="277" alt="image" src="https://github.com/user-attachments/assets/acaba135-16e0-4e85-8288-9d8319768020" />
In light theme
<br>

This solves the issue #108 