### PR TITLE
feat/add a toggle to include readme in create new project dialog

### DIFF
--- a/app/components/hub/CreateNewProjectDialog.tsx
+++ b/app/components/hub/CreateNewProjectDialog.tsx
@@ -2,6 +2,7 @@ import { Dialog, DialogClose, DialogRoot, DialogTitle, DialogDescription } from 
 import { Button } from '~/components/ui/Button';
 import { Input } from '~/components/ui/Input';
 import { Label } from '~/components/ui/Label';
+import { Switch } from '~/components/ui/Switch';
 import { useState } from 'react';
 import { classNames } from '~/utils/classNames';
 import { toast } from 'react-toastify';
@@ -26,6 +27,7 @@ export function CreateNewProjectDialog({ isOpen, onClose }: CreateNewProjectDial
   const [repoName, setRepoName] = useState('');
   const [description, setDescription] = useState('');
   const [isPrivate, setIsPrivate] = useState(false);
+  const [includeReadme, setIncludeReadme] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -43,6 +45,7 @@ export function CreateNewProjectDialog({ isOpen, onClose }: CreateNewProjectDial
           repoName,
           description,
           isPrivate,
+          autoInit: includeReadme, // Send readme preference to API
         }),
       });
 
@@ -150,6 +153,15 @@ export function CreateNewProjectDialog({ isOpen, onClose }: CreateNewProjectDial
                 </div>
               </div>
             </div>
+          </div>
+          <div className="flex items-center justify-between pt-2">
+            <div>
+              <Label htmlFor="include-readme" className="text-gitmesh-elements-textPrimary font-medium">
+                Add README
+              </Label>
+              <p className="text-sm text-gitmesh-elements-textSecondary">READMEs can be used as longer descriptions.</p>
+            </div>
+            <Switch checked={includeReadme} onCheckedChange={setIncludeReadme} />
           </div>
           {error && (
             <div className="p-3 rounded-lg bg-red-50 border border-red-200 dark:bg-red-900/20 dark:border-red-700">

--- a/app/routes/api.github-create-repo.ts
+++ b/app/routes/api.github-create-repo.ts
@@ -6,6 +6,7 @@ interface CreateRepoRequestBody {
   repoName?: string;
   description?: string;
   isPrivate?: boolean;
+  autoInit?: boolean;
 }
 
 // Define a basic shape for a potential GitHub API error
@@ -35,7 +36,7 @@ async function createRepoAction({ request, context: _context }: ActionFunctionAr
       return json({ error: 'GitHub token not found in cookies' }, { status: 401 });
     }
 
-    const { repoName, description, isPrivate } = (await request.json()) as CreateRepoRequestBody;
+    const { repoName, description, isPrivate, autoInit } = (await request.json()) as CreateRepoRequestBody;
 
     if (!repoName) {
       return json({ error: 'Repository name is required' }, { status: 400 });
@@ -53,6 +54,7 @@ async function createRepoAction({ request, context: _context }: ActionFunctionAr
         name: repoName,
         description,
         private: isPrivate,
+        auto_init: autoInit,
       }),
     });
 


### PR DESCRIPTION

## Description

This PR adds a toggle switch to Add Readme file in Create New Project dialog.

## Related Issue

Fixes #117

## Type of Change

- [x] `feat:` New feature

## How I Solved the Issue

I have added a toggle switch in the dialog used to create a new project, using the switch component defined in ui components.
Then updated the API route used to create new project - app/routes/api.github-create-repo.ts , to add a README.md file depending on the state of the toggle switch

## Screenshots 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/90d947c0-5e06-4057-81f2-86afd55d1e1c" />