### PR TITLE
Fix /gov commands for role change in steward bot.

### DIFF
--- a/.github/workflows/gov-sync.yml
+++ b/.github/workflows/gov-sync.yml
@@ -13,8 +13,8 @@ on:
     - cron: '0 0 * * *' 
   pull_request:
     types: [closed]
-    paths:
-      - 'governance/contributors.yaml'
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
@@ -31,7 +31,8 @@ jobs:
       (github.event_name == 'schedule' || 
        github.event_name == 'workflow_dispatch' ||
        github.event_name == 'push' ||
-       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)) &&
+       github.event_name == 'issue_comment' ||
+       (github.event_name == 'pull_request')) &&
       (github.event.head_commit.author.email != '41898282+github-actions[bot]@users.noreply.github.com' || 
        github.event.head_commit.author.email == null) &&
       (github.event.pull_request.title != 'chore(gov): automated governance registry & history sync' ||
@@ -40,6 +41,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write 
+      issues: write
     
     steps:
       - name: Checkout Code
@@ -59,10 +61,17 @@ jobs:
       - name: Execute Governance Logic
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: python .github/scripts/governance_engine.py
 
       # Create a PR with updates instead of pushing directly to main
       - name: Commit and Create/Update PR
+        if: |
+          github.event_name == 'schedule' || 
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'push' ||
+          (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
@@ -103,7 +112,7 @@ jobs:
           
           # Extract Code Owners from .github/CODEOWNERS for notification
           CODE_OWNERS=""
-          if [ -f ".github/CODEOWNERS" ]; then
+          if [ "${{ github.repository }}" == "LF-Decentralized-Trust-labs/gitmesh" ] && [ -f ".github/CODEOWNERS" ]; then
             # Find line matching governance/contributors.yaml and extract @usernames
             CODE_OWNERS=$(grep "governance/contributors.yaml" .github/CODEOWNERS | grep -o "@[a-zA-Z0-9-]*" | tr '\n' ' ')
           fi


### PR DESCRIPTION
## Fix: gov Commands for role change in steward bot

## Summary

This PR fixes /gov commands for role change in the GitHub Steward Bot. Adds two /gov commands for promotion or demotion of a contributor in governance. Code Owners can now use these commands in comments of any open PR.
- ```/gov promote @username "Role"```
- ```/gov demote @username "Role"```

## Related Issue
Fixes #217 

## Workflow 

- Bot recognizes the command
- Validates permissions (CODEOWNERS only)
- Updates role in contributors.yaml
- Logs event in governance history/ledger
- Adds commit to the same PR
- Confirms action via a bot comment

## Type of Change

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore


## How Was This Tested?

- [X] Local run
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

Notes:


## CE & Security Check

- [x] Targets **GitMesh CE** only (no EE code)
- [x] No secrets or credentials committed

## Checklist

- [x] Code follows project style
- [X] Self-reviewed
- [x] Tests updated/added where needed
