### PR TITLE
Update GitHub steward bot schedule and fix case mismatch

### DIFF
--- a/.github/scripts/governance_engine.py
+++ b/.github/scripts/governance_engine.py
@@ -50,7 +50,7 @@ def get_authorized_users():
                     parts = line.split()
                     for part in parts:
                         if part.startswith('@'):
-                            authorized.add(part.lstrip('@'))
+                            authorized.add(part.lstrip('@').lower())
     except Exception as e:
         print(f"Error parsing CODEOWNERS: {e}")
     
@@ -285,7 +285,7 @@ def run_command_mode(event_path, event_name):
     
     # Authorization
     authorized_users = get_authorized_users()
-    if author not in authorized_users:
+    if author.lower() not in authorized_users:
         post_comment(pr_number, f"⛔ **Permission Denied**: @{author} is not a registered code owner for governance.")
         return
 

--- a/.github/workflows/gov-sync.yml
+++ b/.github/workflows/gov-sync.yml
@@ -10,29 +10,19 @@ name: GitMesh Steward Bot
 
 on:
   schedule:
-    - cron: '0 0 * * *' 
-  pull_request:
-    types: [closed]
+    - cron: '30 1 * * 5' # Weekly on Friday at 07:00 IST (01:30 UTC)
   issue_comment:
     types: [created]
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - 'governance/**'
-      - '.github/workflows/gov-sync.yml'
   workflow_dispatch:  # Allow manual trigger
 
 jobs:
   sync-engine:
-    # Run on schedule, manual trigger, push to main, or merged PR
+    # Run on schedule, manual trigger, or issue comment (commands)
     # IMPORTANT: Skip if triggered by the bot's own commits or PRs to prevent infinite loops
     if: |
       (github.event_name == 'schedule' || 
        github.event_name == 'workflow_dispatch' ||
-       github.event_name == 'push' ||
-       github.event_name == 'issue_comment' ||
-       (github.event_name == 'pull_request')) &&
+       github.event_name == 'issue_comment') &&
       (github.event.head_commit.author.email != '41898282+github-actions[bot]@users.noreply.github.com' || 
        github.event.head_commit.author.email == null) &&
       (github.event.pull_request.title != 'chore(gov): automated governance registry & history sync' ||
@@ -69,9 +59,7 @@ jobs:
       - name: Commit and Create/Update PR
         if: |
           github.event_name == 'schedule' || 
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'push' ||
-          (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)
+          github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
@@ -93,7 +81,7 @@ jobs:
           export GITHUB_TOKEN=$GH_TOKEN
           
           # Check if an open governance sync PR already exists (search by title pattern)
-          EXISTING_PR=$(gh pr list --base main --state open --json number,title --jq '.[] | select(.title | startswith("chore(gov): auto-sync")) | .number' | head -1 || echo "")
+          EXISTING_PR=$(gh pr list --base main --state open --json number,title --jq '.[] | select(.title | startswith("chore(gov): automated governance registry")) | .number' | head -1 || echo "")
           
           if [ -n "$EXISTING_PR" ]; then
             echo "An open governance sync PR already exists (PR #$EXISTING_PR). Skipping PR creation."


### PR DESCRIPTION
## fix : Update GitHub steward bot schedule and fix case mismatch

## Summary

Fixes case mismatch in /gov commands and updates the workflow trigger of GitHub Steward bot to run weekly, and not daily or on a pull request merge.

## Related Issue

Fixes #293 


## Type of Change

- [ ] feat
- [X] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore


## How Was This Tested?

- [X] Local run
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

## CE & Security Check

- [X] Targets **GitMesh CE** only (no EE code)
- [X] No secrets or credentials committed

## Checklist

- [X] Code follows project style
- [X] Self-reviewed
- [X] Tests updated/added where needed
