### PR TITLE
feat: run Ollama natively on host instead of Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,52 @@ Before joining the pack, ensure you have:
   - Verify installation: `echo $PATH` (look for `/usr/local/bin`)
 - **Docker & Docker Compose** – [Installation guide](https://docs.docker.com/get-docker/)
 - **Git** – [Git Download](https://git-scm.com/downloads)
+- **Ollama** *(optional, for local AI features)* – [Download here](https://ollama.com/download)
+
+### Ollama Setup (Optional — Local AI)
+
+GitMesh uses Ollama for local AI-powered features (issue prioritization, sprint suggestions, spec generation). Ollama runs **on your host system** (not in Docker) for better performance and GPU support.
+
+<details>
+<summary><strong>Install & Configure Ollama</strong></summary>
+
+**1. Install Ollama on your host:**
+
+```bash
+# Linux
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Or download from https://ollama.com/download
+```
+
+**2. Pull a model:**
+
+```bash
+ollama pull llama3.2:3b
+```
+
+**3. Verify it's running:**
+
+```bash
+curl http://localhost:11434
+# Should return: "Ollama is running"
+```
+
+**4. Enable Ollama in GitMesh:**
+
+Add these environment variables to your backend override file (`backend/.env.override.local` or `backend/.env.override.composed`):
+
+```bash
+OLLAMA_ENABLED=true
+OLLAMA_URL=http://host.docker.internal:11434
+OLLAMA_MODEL=llama3.2:3b
+```
+
+> **Linux Docker users:** If `host.docker.internal` doesn't resolve, add `--add-host=host.docker.internal:host-gateway` to your Docker run command, or use your host's LAN IP (e.g., `http://192.168.1.x:11434`).
+
+**Without Ollama:** GitMesh works perfectly fine without it. If no AI provider is configured, workflow endpoints return deterministic fallback responses. You can also use cloud providers (OpenAI, Anthropic, Groq, etc.) by setting their API keys.
+
+</details>
 
 ### Launch Sequence
 

--- a/backend/src/serverless/microservices/python/crewai-devtel/app/main.py
+++ b/backend/src/serverless/microservices/python/crewai-devtel/app/main.py
@@ -1,7 +1,7 @@
 """
 DevTel AI Service
 Multi-provider AI service supporting latest models (2024/2025):
-- Ollama (development - local)
+- Ollama (development - runs on host system, not in Docker)
 - OpenAI: GPT-4o, GPT-4o-mini, o1-preview
 - Anthropic: Claude 3.5 Sonnet/Haiku
 - Google: Gemini 2.0 Flash, 1.5 Pro
@@ -37,9 +37,11 @@ app.add_middleware(
 SERVICE_TOKEN = os.getenv("CREWAI_SERVICE_TOKEN", "dev-token")
 AI_PROVIDER = os.getenv("AI_PROVIDER", "auto")
 
-# Ollama (local LLM)
-OLLAMA_ENABLED = os.getenv("OLLAMA_ENABLED", "true").lower() == "true"
-OLLAMA_URL = os.getenv("OLLAMA_URL", "http://ollama:11434")
+# Ollama (local LLM - runs on host system, not in Docker)
+# Install Ollama on your host: https://ollama.com/download
+# Then pull a model: ollama pull llama3.2:3b
+OLLAMA_ENABLED = os.getenv("OLLAMA_ENABLED", "false").lower() == "true"
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://host.docker.internal:11434")
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama3.2:3b")
 
 # Cloud providers
@@ -280,7 +282,7 @@ def get_active_provider() -> str:
     if AI_PROVIDER != "auto":
         return AI_PROVIDER
     
-    # Auto-detect: prefer cloud providers, fallback to Ollama
+    # Auto-detect: prefer cloud providers, fallback to Ollama if enabled
     if OPENAI_API_KEY:
         return "openai"
     if ANTHROPIC_API_KEY:
@@ -296,8 +298,8 @@ def get_active_provider() -> str:
     if OLLAMA_ENABLED:
         return "ollama"
     
-    # Ultimate fallback
-    return "ollama"
+    # No provider configured — workflows will use deterministic fallbacks
+    return "none"
 
 
 ACTIVE_PROVIDER = get_active_provider()
@@ -319,8 +321,12 @@ def get_ai_client() -> AIClient:
         return TogetherClient(TOGETHER_API_KEY, TOGETHER_MODEL)
     elif provider == "deepseek":
         return DeepSeekClient(DEEPSEEK_API_KEY, DEEPSEEK_MODEL)
-    else:
+    elif provider == "ollama":
         return OllamaClient(OLLAMA_URL, OLLAMA_MODEL)
+    else:
+        # No provider configured — return a no-op client
+        # Workflow endpoints will use their deterministic fallbacks
+        return AIClient()
 
 
 ai_client = get_ai_client()
@@ -366,11 +372,12 @@ async def health_check():
         "together": TOGETHER_MODEL,
         "deepseek": DEEPSEEK_MODEL,
     }
-    status["model"] = model_map.get(ACTIVE_PROVIDER, "unknown")
+    status["model"] = model_map.get(ACTIVE_PROVIDER, "none (using fallback responses)")
     
     if OLLAMA_ENABLED and ACTIVE_PROVIDER == "ollama":
         ollama = OllamaClient(OLLAMA_URL, OLLAMA_MODEL)
         status["ollama_connected"] = await ollama.is_available()
+        status["ollama_url"] = OLLAMA_URL
     
     return status
 

--- a/scripts/cli
+++ b/scripts/cli
@@ -629,7 +629,9 @@ function check_container_health() {
     
     if [[ "$status" == "running" ]]; then
         # Check health status if available
-        local health_status=$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>/dev/null || echo "none")
+        local health_status
+        health_status=$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>/dev/null) || health_status="none"
+        health_status=$(echo "$health_status" | tr -d '[:space:]')
         [[ -z "$health_status" ]] && health_status="none"
         
         if [[ "$health_status" == "healthy" ]]; then
@@ -673,7 +675,10 @@ function check_application_service_health() {
     
     if [[ "$status" == "running" ]]; then
         # Check health status if available
-        local health_status=$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>/dev/null || echo "none")
+        local health_status
+        health_status=$(docker inspect --format='{{.State.Health.Status}}' "$container_id" 2>/dev/null) || health_status="none"
+        health_status=$(echo "$health_status" | tr -d '[:space:]')
+        [[ -z "$health_status" ]] && health_status="none"
         
         if [[ "$health_status" == "healthy" ]]; then
             echo "${GREEN}healthy${RESET}"
@@ -913,11 +918,12 @@ function print_success_and_ports() {
     [[ "$sqs_status" == *"unhealthy"* ]] && ((unhealthy_count++))
     [[ "$sqs_status" != *"not running"* ]] && ((total_services++))
     
-    # Check Ollama - has HTTP endpoint
-    local ollama_status=$(check_http_service_health "ollama" "http://localhost:11434")
-    echo -e "${BLUE}Ollama:${RESET}               http://localhost:11434 - $ollama_status"
-    [[ "$ollama_status" == *"unhealthy"* ]] && ((unhealthy_count++))
-    [[ "$ollama_status" != *"not running"* ]] && ((total_services++))
+    # Check Ollama (host system) - optional, not managed by Docker
+    if curl -sf http://localhost:11434 > /dev/null 2>&1; then
+        echo -e "${BLUE}Ollama (host):${RESET}        http://localhost:11434 - ${GREEN}✓ running${RESET}"
+    else
+        echo -e "${BLUE}Ollama (host):${RESET}        http://localhost:11434 - ${GREY}not running (optional)${RESET}"
+    fi
     
     # Check Unleash (only for EE) - has HTTP endpoint
     if [[ "$__EDITION" == "gitmesh-ee" ]]; then

--- a/scripts/scaffold.yaml
+++ b/scripts/scaffold.yaml
@@ -231,31 +231,6 @@ services:
     networks:
       - gitmesh-bridge
 
-  # Ollama - Local open-source LLM server
-  ollama:
-    image: ollama/ollama:latest
-    restart: always
-    ports:
-      - "11434:11434"
-    volumes:
-      - ollama-dev:/root/.ollama
-    healthcheck:
-      test: ["CMD", "ollama", "list"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    networks:
-      - gitmesh-bridge
-    # Uncomment below for GPU support (NVIDIA)
-    # deploy:
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - driver: nvidia
-    #           count: all
-    #           capabilities: [gpu]
-
 networks:
   gitmesh-bridge:
     external: true
@@ -265,4 +240,3 @@ volumes:
   opensearch-dev:
   s3-dev:
   redis-dev:
-  ollama-dev:


### PR DESCRIPTION
## PR Title

feat: run Ollama natively on host instead of Docker container


## Summary

Removes Ollama from the Docker Compose scaffold to reduce dev environment weight and improve GPU support. Ollama now runs on the host system, and the backend connects to it via `host.docker.internal:11434`. AI features gracefully fall back to deterministic responses if Ollama is not running.


## Related Issue

Closes #362


## Type of Change

- [x] feat


## How Was This Tested?

- [x] Local run
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

Notes: Started `./cli dev` after changes — scaffold boots without Ollama container. Verified host Ollama detection in CLI status output.


## CE & Security Check

- [x] Targets **GitMesh CE** only (no EE code)
- [x] No secrets or credentials committed


## Screenshots / Demos (if UI or UX)

No UI changes.


## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [ ] Tests updated/added where needed
