### PR TITLE
fix: restrict governance activity check to target repo

### DIFF
--- a/.github/scripts/governance_engine.py
+++ b/.github/scripts/governance_engine.py
@@ -159,17 +159,31 @@ def get_merged_prs(since_date=None, per_page=100):
             
     return all_prs
 
-def get_last_activity_date(username):
-    """Queries GitHub Events API to find the user's latest public action."""
-    url = f"https://api.github.com/users/{username}/events/public"
-    try:
-        response = requests.get(url, headers=headers)
-        if response.status_code == 200:
-            events = response.json()
-            if events and isinstance(events, list):
-                return events[0]['created_at'].split('T')[0]
-    except Exception as e:
-        print(f"Error fetching activity for {username}: {e}")
+def get_last_activity_date(username, max_pages=3):
+    """Queries GitHub Events API to find the user's latest public action in the target repository."""
+    for page in range(1, max_pages + 1):
+        url = f"https://api.github.com/users/{username}/events/public?per_page=100&page={page}"
+        try:
+            response = requests.get(url, headers=headers)
+            if response.status_code == 200:
+                events = response.json()
+                if not events or not isinstance(events, list):
+                    break
+                
+                for event in events:
+                    repo_name = event.get('repo', {}).get('name')
+                    # event['repo']['name'] usually returns 'owner/repo' which matches the REPO format.
+                    if repo_name == REPO:
+                        return event['created_at'].split('T')[0]
+                
+                if len(events) < 100:
+                    break
+            else:
+                break
+        except Exception as e:
+            print(f"Error fetching activity for {username} on page {page}: {e}")
+            break
+            
     return None
 
 def update_user_history(username, event_type, details, is_bot=False):


### PR DESCRIPTION
## PR Title

fix: restrict governance activity check to target repo


## Summary

This PR updates the `get_last_activity_date` in the governance engine to iterate through the user's public GitHub events. It checks the specific repository (`LF-Decentralized-Trust-labs/gitmesh`) to prevent contributors with activity elsewhere from being incorrectly marked as active here.


## Related Issue

Fixes #221


## Type of Change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore


## How Was This Tested?

- [x] Local run
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

Notes: Verified via an ad-hoc local script by testing specific users (`focuzd` and `vibhor-5`) against the GitHub Events API.


## CE & Security Check

- [x] Targets **GitMesh CE** only (no EE code)
- [x] No secrets or credentials committed


## Screenshots / Demos (if UI or UX)


## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Tests updated/added where needed
