### PR TITLE
docs: streamline .env.example for local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,56 +1,25 @@
-# ─── GitMesh Agents — Environment Configuration ──────────────────────────────
-# Copy this file to `.env` (the bootstrap script does this for you).
-# Defaults below are tuned for a one-command local-dev experience: leave most
-# values blank and the embedded Postgres + local_trusted auth will just work.
-
-# ─── Server ──────────────────────────────────────────────────────────────────
-PORT=3100
+# Copy to `.env` (setup scripts do this if missing).
+PORT=3200
 SERVE_UI=true
-
-# Leave DATABASE_URL UNSET to use the embedded PostgreSQL at
-# ~/.gitmesh-agents/instances/default/db/. Only set it to point at an external
-# Postgres (e.g. Docker compose at port 5433):
-#   DATABASE_URL=postgres://gitmesh:gitmesh@localhost:5433/gitmesh
-#DATABASE_URL=
-
-# ─── Deployment mode ─────────────────────────────────────────────────────────
-# local_trusted   = no auth, single-operator dev mode (DEFAULT — "just works")
-# authenticated   = better-auth required; needs GITHUB_CLIENT_ID/SECRET below
 GITMESH_DEPLOYMENT_MODE=local_trusted
-GITMESH_PUBLIC_URL=http://localhost:3100
+GITMESH_PUBLIC_URL=http://localhost:3200
+GITMESH_MIGRATION_PROMPT=never
 
-# Required only when GITMESH_DEPLOYMENT_MODE=authenticated.
-# Generate with:  openssl rand -base64 32
+# GitHub in local_trusted: set a PAT from https://github.com/settings/tokens (repo, admin:repo_hook, read:user, user:email).
+GITHUB_LOCAL_DEV_PAT=
+
+# External Postgres (unset = embedded DB under ~/.gitmesh-agents/...)
+#DATABASE_URL=postgres://gitmesh:gitmesh@localhost:5433/gitmesh
+
+# authenticated / OAuth (callback http://localhost:3200/api/auth/callback/github)
 BETTER_AUTH_SECRET=
-BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3100,http://127.0.0.1:3100,http://localhost:5173
-
-# Agent JWT signing secret. Used by the local-agent JWT auth path. Falls back
-# to BETTER_AUTH_SECRET if not set. Generate with: openssl rand -base64 32
-GITMESH_AGENT_JWT_SECRET=
-
-# ─── GitHub Integration ──────────────────────────────────────────────────────
-# Two ways to connect GitHub in local dev:
-#
-# (1) GITHUB_LOCAL_DEV_PAT — easiest. Create a Personal Access Token at
-#     https://github.com/settings/tokens with scopes: repo, admin:repo_hook,
-#     read:user, user:email. The server will use this token instead of OAuth
-#     when running in local_trusted mode and no signed-in user account is
-#     available. This unblocks repo listing, cloning, and webhook ops without
-#     setting up a GitHub OAuth App.
-#GITHUB_LOCAL_DEV_PAT=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-#
-# (2) GitHub OAuth App — required for authenticated mode and multi-user setups.
-#     Register at https://github.com/settings/developers with callback URL
-#     http://localhost:3100/api/auth/callback/github
+BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3200,http://127.0.0.1:3200,http://localhost:5173
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+GITMESH_AGENT_JWT_SECRET=
 
-# Where to clone repos when "Connect Project" runs. Default keeps everything
-# under the GitMesh home directory so a single rm -rf wipes all dev state.
+#GITMESH_MIGRATION_AUTO_APPLY=true
 #GITMESH_REPO_CLONE_ROOT=~/.gitmesh-agents/instances/default/repos
-
-# ─── Optional: secrets / storage / scheduler ─────────────────────────────────
-# Most users do not need these.
 #GITMESH_SECRETS_PROVIDER=local
 #GITMESH_SECRETS_MASTER_KEY=
 #GITMESH_SECRETS_STRICT_MODE=false
@@ -59,14 +28,10 @@ GITHUB_CLIENT_SECRET=
 #GITMESH_ENABLE_PROJECT_DELETION=true
 #HEARTBEAT_SCHEDULER_ENABLED=true
 #HEARTBEAT_SCHEDULER_INTERVAL_MS=15000
-
-# ─── Optional: instance overrides ────────────────────────────────────────────
 #GITMESH_HOME=~/.gitmesh-agents
 #GITMESH_INSTANCE_ID=default
 #GITMESH_DEPLOYMENT_EXPOSURE=local-only
 #GITMESH_ALLOWED_HOSTNAMES=
 #GITMESH_LOG_DIR=
-
-# ─── Optional: LLM API keys (for Claude/OpenAI adapters that don't use a gateway)
 #ANTHROPIC_API_KEY=
 #OPENAI_API_KEY=


### PR DESCRIPTION
## PR Title

docs: streamline .env.example for local dev

## Summary

Restructures **`.env.example`** so **`local_trusted`** defaults come first (port, public URL, **`GITMESH_MIGRATION_PROMPT`**), puts **`GITHUB_LOCAL_DEV_PAT`** next for GitHub connectivity, and moves **`DATABASE_URL`**, authenticated/OAuth, and optional toggles below with shorter comments. The branch also **merges `origin/main`** (includes **PR #382** already on main) so **`pivot-monorepo-layout`** stays aligned with upstream.

## Related Issue

N/A

## Type of Change

- [ ] feat
- [ ] fix
- [x] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [x] chore

## How Was This Tested?

- [x] Local run
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

**Notes:** Skim **`.env.example`** and copy to a scratch `.env` to confirm variables match your dev flow; no runtime code paths changed.

## CE & Security Check

- [x] Targets **GitMesh CE** only (no EE code)
- [x] No secrets or credentials committed

## Screenshots / Demos (if UI or UX)

N/A

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [ ] Tests updated/added where needed