### PR TITLE
fix: support Windows fake cursor execute commands

### DIFF
--- a/server/src/__tests__/cursor-local-execute.test.ts
+++ b/server/src/__tests__/cursor-local-execute.test.ts
@@ -4,40 +4,27 @@ import os from "node:os";
 import path from "node:path";
 import { execute } from "@gitmesh/adapter-cursor-local/server";
 
-async function writeFakeCursorCommand(commandPath: string): Promise<void> {
-  const script = `#!/usr/bin/env node
-const fs = require("node:fs");
-
-const capturePath = process.env.GITMESH_TEST_CAPTURE_PATH;
-const payload = {
-  argv: process.argv.slice(2),
-  prompt: fs.readFileSync(0, "utf8"),
-  gitmeshAgentsEnvKeys: Object.keys(process.env)
-    .filter((key) => key.startsWith("GITMESH_"))
-    .sort(),
-};
-if (capturePath) {
-  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
-}
-console.log(JSON.stringify({
-  type: "system",
-  subtype: "init",
-  session_id: "cursor-session-1",
-  model: "auto",
-}));
-console.log(JSON.stringify({
-  type: "assistant",
-  message: { content: [{ type: "output_text", text: "hello" }] },
-}));
-console.log(JSON.stringify({
-  type: "result",
-  subtype: "success",
-  session_id: "cursor-session-1",
-  result: "ok",
-}));
-`;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
+async function writeFakeCursorCommand(
+  commandPath: string,
+  capturePath: string,
+): Promise<void> {
+  if (process.platform === "win32") {
+    await fs.writeFile(
+      commandPath,
+      `@echo off
+node -e "const fs=require('fs');fs.writeFileSync(process.argv[1], JSON.stringify({ argv: process.argv.slice(2), env: process.env }, null, 2));" "${capturePath}" %*
+exit /b 0
+`,
+    );
+  } else {
+    await fs.writeFile(
+      commandPath,
+      `#!/bin/sh
+node -e 'const fs=require("fs");fs.writeFileSync(process.argv[1], JSON.stringify({ argv: process.argv.slice(2), env: process.env }, null, 2));' "${capturePath}" "$@"
+`,
+      { mode: 0o755 },
+    );
+  }
 }
 
 type CapturePayload = {
@@ -50,7 +37,10 @@ describe("cursor execute", () => {
   it("injects gitmesh-agents env vars and prompt note by default", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "gitmesh-agents-cursor-execute-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "agent");
+    const commandPath = path.join(
+      root,
+      process.platform === "win32" ? "agent.cmd" : "agent",
+    );
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
     await writeFakeCursorCommand(commandPath);

--- a/server/src/__tests__/cursor-local-execute.test.ts
+++ b/server/src/__tests__/cursor-local-execute.test.ts
@@ -9,18 +9,34 @@ async function writeFakeCursorCommand(
   capturePath: string,
 ): Promise<void> {
   if (process.platform === "win32") {
+    // Windows .cmd script — read stdin as plain text (the prompt),
     await fs.writeFile(
       commandPath,
       `@echo off
-node -e "const fs=require('fs');fs.writeFileSync(process.argv[1], JSON.stringify({ argv: process.argv.slice(2), env: process.env }, null, 2));" "${capturePath}" %*
-exit /b 0
+set GITMESH_TEST_CAPTURE_PATH=${capturePath.replace(/\\/g, "\\\\")}
+node -e "const fs=require('fs');let stdin='';process.stdin.on('data',d=>stdin+=d);process.stdin.on('end',()=>{const prompt=stdin;const gitmeshAgentsEnvKeys=Object.keys(process.env).filter(k=>k.startsWith('GITMESH_')).sort();const payload={prompt,gitmeshAgentsEnvKeys};const p=process.env.GITMESH_TEST_CAPTURE_PATH;if(p){fs.writeFileSync(p,JSON.stringify(payload,null,2));}});" %*
 `,
+      { mode: 0o755 },
     );
   } else {
+    // Unix shell script — same logic, but readable multi-line Node script.
     await fs.writeFile(
       commandPath,
-      `#!/bin/sh
-node -e 'const fs=require("fs");fs.writeFileSync(process.argv[1], JSON.stringify({ argv: process.argv.slice(2), env: process.env }, null, 2));' "${capturePath}" "$@"
+      `#!/usr/bin/env node
+const fs = require('fs');
+let stdin = '';
+process.stdin.on('data', (chunk) => { stdin += chunk; });
+process.stdin.on('end', () => {
+  const prompt = stdin;
+  const gitmeshAgentsEnvKeys = Object.keys(process.env)
+    .filter((k) => k.startsWith('GITMESH_'))
+    .sort();
+  const payload = { prompt, gitmeshAgentsEnvKeys };
+  const capturePath = process.env.GITMESH_TEST_CAPTURE_PATH;
+  if (capturePath) {
+    fs.writeFileSync(capturePath, JSON.stringify(payload, null, 2));
+  }
+});
 `,
       { mode: 0o755 },
     );
@@ -43,7 +59,7 @@ describe("cursor execute", () => {
     );
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
-    await writeFakeCursorCommand(commandPath);
+    await writeFakeCursorCommand(commandPath, capturePath);
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;
@@ -115,10 +131,13 @@ describe("cursor execute", () => {
   it("passes --mode when explicitly configured", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "gitmesh-agents-cursor-execute-mode-"));
     const workspace = path.join(root, "workspace");
-    const commandPath = path.join(root, "agent");
+    const commandPath = path.join(
+      root,
+      process.platform === "win32" ? "agent.cmd" : "agent",
+    );
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
-    await writeFakeCursorCommand(commandPath);
+    await writeFakeCursorCommand(commandPath, capturePath);
 
     const previousHome = process.env.HOME;
     process.env.HOME = root;

--- a/server/src/__tests__/cursor-local-execute.test.ts
+++ b/server/src/__tests__/cursor-local-execute.test.ts
@@ -54,7 +54,7 @@ process.stdin.on("end", () => {
     await fs.writeFile(
       commandPath,
       `@echo off
-set GITMESH_TEST_CAPTURE_PATH=${capturePath.replace(/\\/g, "\\\\")}
+set "GITMESH_TEST_CAPTURE_PATH=${capturePath}"
 node "%~dp0agent" %*
 `,
       "utf8",

--- a/server/src/__tests__/cursor-local-execute.test.ts
+++ b/server/src/__tests__/cursor-local-execute.test.ts
@@ -8,38 +8,59 @@ async function writeFakeCursorCommand(
   commandPath: string,
   capturePath: string,
 ): Promise<void> {
+  const nodeScript = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+let stdin = "";
+process.stdin.on("data", (chunk) => {
+  stdin += chunk;
+});
+
+process.stdin.on("end", () => {
+  const capturePath = process.env.GITMESH_TEST_CAPTURE_PATH;
+  const payload = {
+    argv: process.argv.slice(2),
+    prompt: stdin,
+    gitmeshAgentsEnvKeys: Object.keys(process.env)
+      .filter((key) => key.startsWith("GITMESH_"))
+      .sort(),
+  };
+  if (capturePath) {
+    fs.writeFileSync(capturePath, JSON.stringify(payload, null, 2), "utf8");
+  }
+  console.log(JSON.stringify({
+    type: "system",
+    subtype: "init",
+    session_id: "cursor-session-1",
+    model: "auto",
+  }));
+  console.log(JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "output_text", text: "hello" }] },
+  }));
+  console.log(JSON.stringify({
+    type: "result",
+    subtype: "success",
+    session_id: "cursor-session-1",
+    result: "ok",
+  }));
+});
+`;
+
   if (process.platform === "win32") {
-    // Windows .cmd script — read stdin as plain text (the prompt),
+    const dir = path.dirname(commandPath);
+    const scriptPath = path.join(dir, "agent");
+    await fs.writeFile(scriptPath, nodeScript, "utf8");
     await fs.writeFile(
       commandPath,
       `@echo off
 set GITMESH_TEST_CAPTURE_PATH=${capturePath.replace(/\\/g, "\\\\")}
-node -e "const fs=require('fs');let stdin='';process.stdin.on('data',d=>stdin+=d);process.stdin.on('end',()=>{const prompt=stdin;const gitmeshAgentsEnvKeys=Object.keys(process.env).filter(k=>k.startsWith('GITMESH_')).sort();const payload={prompt,gitmeshAgentsEnvKeys};const p=process.env.GITMESH_TEST_CAPTURE_PATH;if(p){fs.writeFileSync(p,JSON.stringify(payload,null,2));}});" %*
+node "%~dp0agent" %*
 `,
-      { mode: 0o755 },
+      "utf8",
     );
   } else {
-    // Unix shell script — same logic, but readable multi-line Node script.
-    await fs.writeFile(
-      commandPath,
-      `#!/usr/bin/env node
-const fs = require('fs');
-let stdin = '';
-process.stdin.on('data', (chunk) => { stdin += chunk; });
-process.stdin.on('end', () => {
-  const prompt = stdin;
-  const gitmeshAgentsEnvKeys = Object.keys(process.env)
-    .filter((k) => k.startsWith('GITMESH_'))
-    .sort();
-  const payload = { prompt, gitmeshAgentsEnvKeys };
-  const capturePath = process.env.GITMESH_TEST_CAPTURE_PATH;
-  if (capturePath) {
-    fs.writeFileSync(capturePath, JSON.stringify(payload, null, 2));
-  }
-});
-`,
-      { mode: 0o755 },
-    );
+    await fs.writeFile(commandPath, nodeScript, { encoding: "utf8", mode: 0o755 });
   }
 }
 


### PR DESCRIPTION
## Summary

This PR improves Windows compatibility for the fake Cursor execute command used in tests. It ensures that the spawned command works correctly across different operating systems.

---

## Changes

* Updated command path handling to be platform-aware
* On Windows, the fake command now uses a `.cmd` extension instead of a plain executable name
* On Unix-based systems, the existing behavior remains unchanged

---

## Why this change is needed

On Windows, Node.js `spawn` cannot execute a file without a proper extension or executable format. Previously, the fake command was being created without a Windows-compatible extension, leading to execution failures during tests.

<img width="778" height="202" alt="cursor-execute-window-error" src="https://github.com/user-attachments/assets/822293a8-4ccd-4065-9996-49fcca47a812" />

---

## Impact

* Fixes Windows-specific command execution issues in cursor execute tests
* Improves cross-platform consistency of test environment setup
* Reduces spawn-related failures on Windows machines and CI environments

---

## Notes

This PR only fixes command resolution for Windows.
Additional runtime or spawn execution issues (if any remain) will be handled separately.
