### PR TITLE
fix: add project access check to agent budget update route

### DIFF
--- a/server/src/__tests__/agent-budget-access.test.ts
+++ b/server/src/__tests__/agent-budget-access.test.ts
@@ -1,0 +1,246 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { costRoutes } from "../api/costs.js";
+import { errorHandler } from "../infra/middleware/index.js";
+
+// ── Mock services ──────────────────────────────────────────────────────────
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  update: vi.fn(),
+  getChainOfCommand: vi.fn(),
+}));
+
+const mockCostService = vi.hoisted(() => ({
+  createEvent: vi.fn(),
+  summary: vi.fn(),
+  byAgent: vi.fn(),
+  byProject: vi.fn(),
+}));
+
+const mockProjectService = vi.hoisted(() => ({
+  update: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../core/index.js", () => ({
+  agentService: () => mockAgentService,
+  costService: () => mockCostService,
+  projectService: () => mockProjectService,
+  logActivity: mockLogActivity,
+}));
+
+// ── Test fixtures ──────────────────────────────────────────────────────────
+
+const PROJECT_A = "project-a";
+const PROJECT_B = "project-b";
+const AGENT_ID = "agent-1";
+const MANAGER_AGENT_ID = "agent-manager";
+const PEER_AGENT_ID = "agent-peer";
+
+const targetAgent = {
+  id: AGENT_ID,
+  projectId: PROJECT_A,
+  name: "worker",
+  role: "general",
+  budgetMonthlyCents: 5000,
+};
+
+const validBody = { budgetMonthlyCents: 10000 };
+
+// ── App factory ────────────────────────────────────────────────────────────
+
+function createApp(actor: Record<string, unknown>) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", costRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("PATCH /agents/:agentId/budgets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgentService.getById.mockResolvedValue(targetAgent);
+    mockAgentService.update.mockResolvedValue({ ...targetAgent, ...validBody });
+    mockAgentService.getChainOfCommand.mockResolvedValue([]);
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  // ── 1. Unauthenticated → 401 ──────────────────────────────────────────
+
+  it("returns 401 for unauthenticated requests", async () => {
+    const app = createApp({ type: "none" });
+
+    const res = await request(app)
+      .patch(`/api/agents/${AGENT_ID}/budgets`)
+      .send(validBody);
+
+    expect(res.status).toBe(401);
+  });
+
+  // ── 2. Operator without project membership → 403 ──────────────────────
+
+  it("returns 403 when operator lacks access to the agent's project", async () => {
+    const app = createApp({
+      type: "operator",
+      userId: "user-1",
+      projectIds: [PROJECT_B], // only has access to project B
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${AGENT_ID}/budgets`)
+      .send(validBody);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("does not have access");
+  });
+
+  // ── 3. Operator with project membership → 200 ─────────────────────────
+
+  it("allows operator with project access to update agent budget", async () => {
+    const app = createApp({
+      type: "operator",
+      userId: "user-1",
+      projectIds: [PROJECT_A],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${AGENT_ID}/budgets`)
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.budgetMonthlyCents).toBe(10000);
+    expect(mockAgentService.update).toHaveBeenCalledWith(AGENT_ID, validBody);
+  });
+
+  // ── 4. Agent updating own budget → 200 ────────────────────────────────
+
+  it("allows agent to update its own budget", async () => {
+    const app = createApp({
+      type: "agent",
+      agentId: AGENT_ID,
+      projectId: PROJECT_A,
+      source: "agent_key",
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${AGENT_ID}/budgets`)
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.budgetMonthlyCents).toBe(10000);
+  });
+
+  // ── 5. Manager agent updating subordinate → 200 ───────────────────────
+
+  it("allows manager agent to update subordinate budget", async () => {
+    // Chain of command for target agent includes the manager
+    mockAgentService.getChainOfCommand.mockResolvedValue([
+      { id: MANAGER_AGENT_ID, name: "manager", role: "admin", title: null },
+    ]);
+
+    const app = createApp({
+      type: "agent",
+      agentId: MANAGER_AGENT_ID,
+      projectId: PROJECT_A,
+      source: "agent_key",
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${AGENT_ID}/budgets`)
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.getChainOfCommand).toHaveBeenCalledWith(AGENT_ID);
+  });
+
+  // ── 6. Non-manager agent updating peer → 403 ──────────────────────────
+
+  it("returns 403 when agent tries to update a peer's budget", async () => {
+    // Chain of command does NOT include the peer agent
+    mockAgentService.getChainOfCommand.mockResolvedValue([]);
+
+    const app = createApp({
+      type: "agent",
+      agentId: PEER_AGENT_ID,
+      projectId: PROJECT_A,
+      source: "agent_key",
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${AGENT_ID}/budgets`)
+      .send(validBody);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("subordinate subtree");
+  });
+
+  // ── 7. Agent from different project → 403 ─────────────────────────────
+
+  it("returns 403 when agent belongs to a different project", async () => {
+    const app = createApp({
+      type: "agent",
+      agentId: "agent-other",
+      projectId: PROJECT_B, // different project
+      source: "agent_key",
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${AGENT_ID}/budgets`)
+      .send(validBody);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("cannot access another project");
+  });
+
+  // ── 8. Agent not found → 404 ──────────────────────────────────────────
+
+  it("returns 404 when the target agent does not exist", async () => {
+    mockAgentService.getById.mockResolvedValue(null);
+
+    const app = createApp({
+      type: "operator",
+      userId: "user-1",
+      projectIds: [PROJECT_A],
+      source: "session",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/nonexistent/budgets`)
+      .send(validBody);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Agent not found");
+  });
+
+  // ── 9. Local implicit operator bypasses project check → 200 ───────────
+
+  it("allows local implicit operator to update any agent budget", async () => {
+    const app = createApp({
+      type: "operator",
+      userId: "operator",
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    });
+
+    const res = await request(app)
+      .patch(`/api/agents/${AGENT_ID}/budgets`)
+      .send(validBody);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/server/src/api/costs.ts
+++ b/server/src/api/costs.ts
@@ -4,6 +4,7 @@ import { createCostEventSchema, updateBudgetSchema } from "@gitmesh/core";
 import { validate } from "../infra/middleware/validate.js";
 import { costService, projectService, agentService, logActivity } from "../core/index.js";
 import { assertBoard, assertProjectAccess, getActorInfo } from "./authz.js";
+import { forbidden } from "../errors.js";
 
 export function costRoutes(db: Db) {
   const router = Router();
@@ -100,9 +101,11 @@ export function costRoutes(db: Db) {
       return;
     }
 
-    // Gate 1: Enforce project boundary for ALL actor types (operator, agent, none).
-    // This is the primary cross-project isolation guard. Without it, an authenticated
-    // operator or agent from another project could freely mutate any agent's budget.
+    // Gate 1: Enforce project boundary for all actor types.
+    // This is the primary cross-project isolation guard: without it, an authenticated
+    // operator (or any other actor with project-scoped access) could target agents in
+    // another project. For agent actors, this limits access to their own project; Gate 2
+    // further restricts them to themselves or agents in their subordinate subtree.
     assertProjectAccess(req, agent.projectId);
 
     // Gate 2: Spec §9.3 — "Set subordinate budget: yes (manager subtree only)" for agents.
@@ -111,23 +114,17 @@ export function costRoutes(db: Db) {
     //   (b) an agent it directly or transitively manages (is in the chain-of-command).
     // Operators bypass this sub-check (Gate 1 is sufficient).
     if (req.actor.type === "agent") {
-      const actorAgentId = req.actor.agentId;
-      if (!actorAgentId) {
-        res.status(403).json({ error: "Agent authentication required" });
-        return;
-      }
+      if (!req.actor.agentId) throw forbidden("Agent authentication required");
 
-      const isSelf = actorAgentId === agentId;
-      if (!isSelf) {
+      if (req.actor.agentId !== agentId) {
         // getChainOfCommand(targetId) walks UP from target → root manager.
         // If actorAgentId appears in that chain, actor is a manager of target.
         const chainOfCommand = await agents.getChainOfCommand(agentId);
-        const isManager = chainOfCommand.some((manager) => manager.id === actorAgentId);
+        const isManager = chainOfCommand.some((m) => m.id === req.actor.agentId);
         if (!isManager) {
-          res.status(403).json({
-            error: "Agent can only set the budget of itself or agents in its subordinate subtree",
-          });
-          return;
+          throw forbidden(
+            "Agent can only set the budget of itself or agents in its subordinate subtree",
+          );
         }
       }
     }

--- a/server/src/api/costs.ts
+++ b/server/src/api/costs.ts
@@ -100,10 +100,35 @@ export function costRoutes(db: Db) {
       return;
     }
 
+    // Gate 1: Enforce project boundary for ALL actor types (operator, agent, none).
+    // This is the primary cross-project isolation guard. Without it, an authenticated
+    // operator or agent from another project could freely mutate any agent's budget.
+    assertProjectAccess(req, agent.projectId);
+
+    // Gate 2: Spec §9.3 — "Set subordinate budget: yes (manager subtree only)" for agents.
+    // An agent actor may only set the budget of:
+    //   (a) itself, OR
+    //   (b) an agent it directly or transitively manages (is in the chain-of-command).
+    // Operators bypass this sub-check (Gate 1 is sufficient).
     if (req.actor.type === "agent") {
-      if (req.actor.agentId !== agentId) {
-        res.status(403).json({ error: "Agent can only change its own budget" });
+      const actorAgentId = req.actor.agentId;
+      if (!actorAgentId) {
+        res.status(403).json({ error: "Agent authentication required" });
         return;
+      }
+
+      const isSelf = actorAgentId === agentId;
+      if (!isSelf) {
+        // getChainOfCommand(targetId) walks UP from target → root manager.
+        // If actorAgentId appears in that chain, actor is a manager of target.
+        const chainOfCommand = await agents.getChainOfCommand(agentId);
+        const isManager = chainOfCommand.some((manager) => manager.id === actorAgentId);
+        if (!isManager) {
+          res.status(403).json({
+            error: "Agent can only set the budget of itself or agents in its subordinate subtree",
+          });
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

`PATCH /agents/:agentId/budgets` had no project boundary check, letting any authenticated operator update an agent's budget across projects. Also fixes the agent permission to correctly allow managers to set subordinate budgets per spec §9.3.

## Type of Change

- [x] fix

## How Was This Tested?

- [x] Local run

Notes: Manually traced the request path for operator (wrong project), unauthenticated, and agent-as-manager scenarios.

## CE & Security Check

- [x] Targets **GitMesh CE** only (no EE code)
- [x] No secrets or credentials committed

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [ ] Tests updated/added where needed
