### PR TITLE
fix: derive approval decidedByUserId from session, not request body

### DIFF
--- a/cli/src/commands/client/approval.ts
+++ b/cli/src/commands/client/approval.ts
@@ -38,7 +38,6 @@ interface ApprovalCreateOpts extends BaseClientOptions {
 
 interface ApprovalDecisionOpts extends BaseClientOptions {
   decisionNote?: string;
-  decidedByUserId?: string;
 }
 
 interface ApprovalResubmitOpts extends BaseClientOptions {
@@ -99,7 +98,6 @@ async function runDecision(
 ): Promise<void> {
   const payload = schema.parse({
     decisionNote: options.decisionNote,
-    decidedByUserId: options.decidedByUserId,
   });
   const updated = await ctx.api.post<Approval>(
     `/api/approvals/${approvalId}/${endpoint}`,
@@ -186,7 +184,6 @@ export function registerApprovalCommands(program: Command): void {
       positional: [{ name: "approvalId", desc: "Approval ID" }],
       options: [
         { flag: "--decision-note <text>", desc: "Decision note" },
-        { flag: "--decided-by-user-id <id>", desc: "Decision actor user ID" },
       ],
       async run(ctx, { positional, options }) {
         const [approvalId] = positional;

--- a/lib/core/src/validators/approval.ts
+++ b/lib/core/src/validators/approval.ts
@@ -11,15 +11,17 @@ export const createApprovalSchema = z.object({
 export type CreateApproval = z.infer<typeof createApprovalSchema>;
 
 export const resolveApprovalSchema = z.object({
+  // decidedByUserId is intentionally absent — the server derives this from
+  // the authenticated session (req.actor.userId). Accepting it from the body
+  // would allow any operator to forge another user's identity in the audit trail.
   decisionNote: z.string().optional().nullable(),
-  decidedByUserId: z.string().optional().default("operator"),
 });
 
 export type ResolveApproval = z.infer<typeof resolveApprovalSchema>;
 
 export const requestApprovalRevisionSchema = z.object({
+  // Same as resolveApprovalSchema — decidedByUserId is server-derived.
   decisionNote: z.string().optional().nullable(),
-  decidedByUserId: z.string().optional().default("operator"),
 });
 
 export type RequestApprovalRevision = z.infer<typeof requestApprovalRevisionSchema>;

--- a/server/src/__tests__/approval-decided-by-session.test.ts
+++ b/server/src/__tests__/approval-decided-by-session.test.ts
@@ -1,0 +1,257 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { approvalRoutes } from "../api/approvals.js";
+import { errorHandler } from "../infra/middleware/index.js";
+
+// ── Mock services ──────────────────────────────────────────────────────────
+
+const mockApprovalService = vi.hoisted(() => ({
+  list: vi.fn(),
+  getById: vi.fn(),
+  create: vi.fn(),
+  approve: vi.fn(),
+  reject: vi.fn(),
+  requestRevision: vi.fn(),
+  resubmit: vi.fn(),
+  listComments: vi.fn(),
+  addComment: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(),
+}));
+
+const mockIssueApprovalService = vi.hoisted(() => ({
+  listIssuesForApproval: vi.fn(),
+  linkManyForApproval: vi.fn(),
+}));
+
+const mockSecretService = vi.hoisted(() => ({
+  normalizeHireApprovalPayloadForPersistence: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../core/index.js", () => ({
+  approvalService: () => mockApprovalService,
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => mockIssueApprovalService,
+  secretService: () => mockSecretService,
+  logActivity: mockLogActivity,
+}));
+
+// ── Test fixtures ──────────────────────────────────────────────────────────
+
+const APPROVAL_ID = "approval-1";
+const PROJECT_ID = "project-1";
+const REAL_USER_ID = "real-session-user";
+const FORGED_USER_ID = "forged-impersonated-user";
+
+function makeApproval(overrides: Record<string, unknown> = {}) {
+  return {
+    id: APPROVAL_ID,
+    projectId: PROJECT_ID,
+    type: "enable_agent",
+    status: "pending",
+    payload: {},
+    requestedByAgentId: null,
+    requestedByUserId: null,
+    decisionNote: null,
+    decidedByUserId: null,
+    decidedAt: null,
+    createdAt: new Date("2026-05-20T00:00:00Z"),
+    updatedAt: new Date("2026-05-20T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+// ── App factory ────────────────────────────────────────────────────────────
+
+function createApp(userId: string = REAL_USER_ID) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "operator",
+      userId,
+      projectIds: [PROJECT_ID],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", approvalRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("approval decision endpoints derive decidedByUserId from session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogActivity.mockResolvedValue(undefined);
+    mockIssueApprovalService.listIssuesForApproval.mockResolvedValue([]);
+  });
+
+  // ── POST /approvals/:id/approve ────────────────────────────────────────
+
+  describe("POST /approvals/:id/approve", () => {
+    it("uses session userId, ignoring any forged decidedByUserId in body", async () => {
+      const approvedApproval = makeApproval({
+        status: "approved",
+        decidedByUserId: REAL_USER_ID,
+      });
+      mockApprovalService.approve.mockResolvedValue(approvedApproval);
+      const app = createApp(REAL_USER_ID);
+
+      const res = await request(app)
+        .post(`/api/approvals/${APPROVAL_ID}/approve`)
+        .send({
+          decisionNote: "Looks good",
+          // Attacker tries to forge another user's identity
+          decidedByUserId: FORGED_USER_ID,
+        });
+
+      expect(res.status).toBe(200);
+      // The service MUST have been called with the session userId, not the forged one
+      expect(mockApprovalService.approve).toHaveBeenCalledWith(
+        APPROVAL_ID,
+        REAL_USER_ID,
+        "Looks good",
+      );
+      // Confirm the forged userId was never passed
+      expect(mockApprovalService.approve).not.toHaveBeenCalledWith(
+        APPROVAL_ID,
+        FORGED_USER_ID,
+        expect.anything(),
+      );
+    });
+
+    it("falls back to 'operator' when userId is undefined", async () => {
+      const approvedApproval = makeApproval({
+        status: "approved",
+        decidedByUserId: "operator",
+      });
+      mockApprovalService.approve.mockResolvedValue(approvedApproval);
+
+      // Build a custom app where the operator actor has no userId set
+      const app = express();
+      app.use(express.json());
+      app.use((req, _res, next) => {
+        (req as any).actor = {
+          type: "operator",
+          source: "local_implicit",
+          isInstanceAdmin: false,
+          // userId intentionally omitted
+        };
+        next();
+      });
+      app.use("/api", approvalRoutes({} as any));
+      app.use(errorHandler);
+
+      const res = await request(app)
+        .post(`/api/approvals/${APPROVAL_ID}/approve`)
+        .send({ decisionNote: null });
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.approve).toHaveBeenCalledWith(
+        APPROVAL_ID,
+        "operator",
+        null,
+      );
+    });
+  });
+
+  // ── POST /approvals/:id/reject ─────────────────────────────────────────
+
+  describe("POST /approvals/:id/reject", () => {
+    it("uses session userId, ignoring any forged decidedByUserId in body", async () => {
+      const rejectedApproval = makeApproval({
+        status: "rejected",
+        decidedByUserId: REAL_USER_ID,
+      });
+      mockApprovalService.reject.mockResolvedValue(rejectedApproval);
+      const app = createApp(REAL_USER_ID);
+
+      const res = await request(app)
+        .post(`/api/approvals/${APPROVAL_ID}/reject`)
+        .send({
+          decisionNote: "Not ready",
+          decidedByUserId: FORGED_USER_ID,
+        });
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.reject).toHaveBeenCalledWith(
+        APPROVAL_ID,
+        REAL_USER_ID,
+        "Not ready",
+      );
+      expect(mockApprovalService.reject).not.toHaveBeenCalledWith(
+        APPROVAL_ID,
+        FORGED_USER_ID,
+        expect.anything(),
+      );
+    });
+  });
+
+  // ── POST /approvals/:id/request-revision ───────────────────────────────
+
+  describe("POST /approvals/:id/request-revision", () => {
+    it("uses session userId, ignoring any forged decidedByUserId in body", async () => {
+      const revisionApproval = makeApproval({
+        status: "revision_requested",
+        decidedByUserId: REAL_USER_ID,
+      });
+      mockApprovalService.requestRevision.mockResolvedValue(revisionApproval);
+      const app = createApp(REAL_USER_ID);
+
+      const res = await request(app)
+        .post(`/api/approvals/${APPROVAL_ID}/request-revision`)
+        .send({
+          decisionNote: "Please revise the config",
+          decidedByUserId: FORGED_USER_ID,
+        });
+
+      expect(res.status).toBe(200);
+      expect(mockApprovalService.requestRevision).toHaveBeenCalledWith(
+        APPROVAL_ID,
+        REAL_USER_ID,
+        "Please revise the config",
+      );
+      expect(mockApprovalService.requestRevision).not.toHaveBeenCalledWith(
+        APPROVAL_ID,
+        FORGED_USER_ID,
+        expect.anything(),
+      );
+    });
+  });
+
+  // ── Non-operator actor is rejected ─────────────────────────────────────
+
+  describe("authorization", () => {
+    it("rejects agent actors from decision endpoints", async () => {
+      const app = express();
+      app.use(express.json());
+      app.use((req, _res, next) => {
+        (req as any).actor = {
+          type: "agent",
+          agentId: "agent-1",
+          projectId: PROJECT_ID,
+          source: "agent_key",
+        };
+        next();
+      });
+      app.use("/api", approvalRoutes({} as any));
+      app.use(errorHandler);
+
+      const res = await request(app)
+        .post(`/api/approvals/${APPROVAL_ID}/approve`)
+        .send({ decisionNote: null });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toContain("Maintainer access required");
+    });
+  });
+});

--- a/server/src/api/approvals.ts
+++ b/server/src/api/approvals.ts
@@ -121,7 +121,11 @@ export function approvalRoutes(db: Db) {
   router.post("/approvals/:id/approve", validate(resolveApprovalSchema), async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;
-    const approval = await svc.approve(id, req.body.decidedByUserId ?? "operator", req.body.decisionNote);
+    // Always derive the decider from the authenticated session — never from the
+    // request body. Trusting the body here would let any operator record a
+    // fabricated userId in approvals.decided_by_user_id (the permanent audit record)
+    // while logActivity correctly records req.actor.userId, creating an inconsistency.
+    const approval = await svc.approve(id, req.actor.userId ?? "operator", req.body.decisionNote);
     const linkedIssues = await issueApprovalsSvc.listIssuesForApproval(approval.id);
     const linkedIssueIds = linkedIssues.map((issue) => issue.id);
     const primaryIssueId = linkedIssueIds[0] ?? null;
@@ -209,7 +213,7 @@ export function approvalRoutes(db: Db) {
   router.post("/approvals/:id/reject", validate(resolveApprovalSchema), async (req, res) => {
     assertBoard(req);
     const id = req.params.id as string;
-    const approval = await svc.reject(id, req.body.decidedByUserId ?? "operator", req.body.decisionNote);
+    const approval = await svc.reject(id, req.actor.userId ?? "operator", req.body.decisionNote);
 
     await logActivity(db, {
       projectId: approval.projectId,
@@ -232,7 +236,7 @@ export function approvalRoutes(db: Db) {
       const id = req.params.id as string;
       const approval = await svc.requestRevision(
         id,
-        req.body.decidedByUserId ?? "operator",
+        req.actor.userId ?? "operator",
         req.body.decisionNote,
       );
 


### PR DESCRIPTION

## Summary
`/approvals/:id/approve|reject|request-revision` was writing `decidedByUserId` from the request body into the permanent audit record, letting any operator forge another user's identity as the approver. The `activity_log` already used `req.actor.userId` correctly, creating an inconsistency between the two audit surfaces.



## Type of Change

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore
## How Was This Tested?

- [x] Local run
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)
## CE & Security Check

- [x] Targets **GitMesh CE** only (no EE code)
- [x] No secrets or credentials committed
## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [ ] Tests updated/added where needed