### PR TITLE
test: cover policy template loading

### DIFF
--- a/server/src/__tests__/policy-templates-loader.test.ts
+++ b/server/src/__tests__/policy-templates-loader.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearPolicyTemplateCache,
+  findPolicyTemplate,
+  getDefaultEnabledTemplates,
+  loadPolicyTemplates,
+} from "../core/policy-templates-loader.js";
+
+describe("policy templates loader", () => {
+  it("loads shipped policy templates without compile errors", () => {
+    clearPolicyTemplateCache();
+
+    const result = loadPolicyTemplates();
+
+    expect(result.loadedFrom).toBeTruthy();
+    expect(result.errors).toEqual([]);
+    expect(result.templates.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("finds templates case-insensitively and exposes default-enabled templates", () => {
+    clearPolicyTemplateCache();
+
+    const ciTemplate = findPolicyTemplate("NO-CI-MODIFICATION");
+    const defaultEnabled = getDefaultEnabledTemplates();
+
+    expect(ciTemplate?.metadata.slug).toBe("no-ci-modification");
+    expect(ciTemplate?.policies[0]?.effect).toBe("block");
+    expect(defaultEnabled.map((template) => template.metadata.slug)).toContain("no-ci-modification");
+  });
+});


### PR DESCRIPTION
﻿## Summary
- add coverage for loading shipped policy templates from `playbooks/policy-templates`
- assert templates compile without loader errors and default-enabled lookup works case-insensitively

## Test plan
- `corepack pnpm vitest run server/src/__tests__/policy-templates-loader.test.ts`
- `corepack pnpm check:tokens`
- `corepack pnpm --filter @gitmesh/server typecheck` *(fails on current main because Express `Request.actor` augmentation file `server/src/types/express.d.ts` is missing; unrelated to this test-only change)*
