### PR TITLE
fix: attest policy evaluation audit entries

### DIFF
--- a/server/src/__tests__/activity-log.test.ts
+++ b/server/src/__tests__/activity-log.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockQueueSign = vi.hoisted(() => vi.fn());
+const mockPublishLiveEvent = vi.hoisted(() => vi.fn());
+
+vi.mock("../core/attestation.js", () => ({
+  attestationService: () => ({
+    queueSign: mockQueueSign,
+  }),
+}));
+
+vi.mock("../core/live-events.js", () => ({
+  publishLiveEvent: mockPublishLiveEvent,
+}));
+
+const { logActivity } = await import("../core/activity-log.js");
+
+function createInsertDb() {
+  const returning = vi.fn().mockResolvedValue([{ id: "activity-1" }]);
+  const values = vi.fn(() => ({ returning }));
+  const insert = vi.fn(() => ({ values }));
+  return {
+    db: { insert },
+    values,
+    returning,
+  };
+}
+
+describe("logActivity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("promotes policy metadata from details into attested activity columns", async () => {
+    const { db, values } = createInsertDb();
+
+    await logActivity(db as never, {
+      projectId: "project-1",
+      actorType: "agent",
+      actorId: "agent-1",
+      action: "acp.register",
+      entityType: "agent",
+      entityId: "agent-1",
+      agentId: "agent-1",
+      details: {
+        policyVersion: 7,
+        policyOutcome: "allow",
+      },
+    });
+
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({
+      policyVersion: 7,
+      policyOutcome: "allow",
+    }));
+    expect(mockQueueSign).toHaveBeenCalledWith({
+      activityId: "activity-1",
+      projectId: "project-1",
+    });
+    expect(mockPublishLiveEvent).toHaveBeenCalledWith(expect.objectContaining({
+      payload: expect.objectContaining({
+        policyVersion: 7,
+        policyOutcome: "allow",
+      }),
+    }));
+  });
+});

--- a/server/src/__tests__/policy-engine-audit.test.ts
+++ b/server/src/__tests__/policy-engine-audit.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../core/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+}));
+
+const { policyEngineService } = await import("../core/policy-engine.js");
+
+function createSelectBuilder(result: unknown[]) {
+  const builder = {
+    from: vi.fn(() => builder),
+    where: vi.fn(() => builder),
+    orderBy: vi.fn(() => Promise.resolve(result)),
+  };
+  return builder;
+}
+
+function createPolicyEngineDb(policyRows: unknown[], agentRows: unknown[]) {
+  return {
+    select: vi
+      .fn()
+      .mockReturnValueOnce(createSelectBuilder(policyRows))
+      .mockReturnValueOnce(createSelectBuilder(agentRows)),
+  };
+}
+
+describe("policyEngineService audit logging", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("routes policy evaluation entries through logActivity with policy metadata", async () => {
+    const policy = {
+      id: "policy-1",
+      projectId: "project-1",
+      name: "Require approval for merges",
+      actionPattern: "merge_pr",
+      conditions: null,
+      effect: "require_approval",
+      effectConfig: { approverRoles: ["maintainer"] },
+      priority: 10,
+      enabled: true,
+      version: 3,
+    };
+    const db = createPolicyEngineDb([policy], [{ id: "agent-1", role: "release" }]);
+
+    const result = await policyEngineService(db as never).evaluate({
+      projectId: "project-1",
+      agentId: "agent-1",
+      action: "merge_pr",
+      context: { targetBranch: "main" },
+    });
+
+    expect(result).toMatchObject({
+      effect: "require_approval",
+      policyId: "policy-1",
+      policyVersion: 3,
+    });
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+    expect(mockLogActivity).toHaveBeenCalledWith(db, {
+      projectId: "project-1",
+      actorType: "agent",
+      actorId: "agent-1",
+      action: "merge_pr",
+      entityType: "policy_evaluation",
+      entityId: "policy-1",
+      agentId: "agent-1",
+      details: {
+        effect: "require_approval",
+        policyName: "Require approval for merges",
+        policyVersion: 3,
+        reason: 'Matched policy "Require approval for merges" (v3)',
+        context: { targetBranch: "main" },
+      },
+      policyVersion: 3,
+      policyOutcome: "require_approval",
+    });
+  });
+});

--- a/server/src/core/activity-log.ts
+++ b/server/src/core/activity-log.ts
@@ -14,10 +14,14 @@ export interface LogActivityInput {
   agentId?: string | null;
   runId?: string | null;
   details?: Record<string, unknown> | null;
+  policyVersion?: number | null;
+  policyOutcome?: string | null;
 }
 
 export async function logActivity(db: Db, input: LogActivityInput) {
   const sanitizedDetails = input.details ? sanitizeRecord(input.details) : null;
+  const policyVersion = input.policyVersion ?? readPolicyVersion(sanitizedDetails);
+  const policyOutcome = input.policyOutcome ?? readPolicyOutcome(sanitizedDetails);
   const inserted = await db
     .insert(activityLog)
     .values({
@@ -30,6 +34,8 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       agentId: input.agentId ?? null,
       runId: input.runId ?? null,
       details: sanitizedDetails,
+      policyVersion,
+      policyOutcome,
     })
     .returning({ id: activityLog.id });
 
@@ -66,6 +72,18 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       agentId: input.agentId ?? null,
       runId: input.runId ?? null,
       details: sanitizedDetails,
+      policyVersion,
+      policyOutcome,
     },
   });
+}
+
+function readPolicyVersion(details: Record<string, unknown> | null): number | null {
+  const value = details?.policyVersion;
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+function readPolicyOutcome(details: Record<string, unknown> | null): string | null {
+  const value = details?.policyOutcome;
+  return typeof value === "string" && value.length > 0 ? value : null;
 }

--- a/server/src/core/policy-engine.ts
+++ b/server/src/core/policy-engine.ts
@@ -14,13 +14,14 @@
 
 import { eq, and, asc } from "@gitmesh/data";
 import type { Db } from "@gitmesh/data";
-import { agentPolicies, activityLog, agents } from "@gitmesh/data";
+import { agentPolicies, agents } from "@gitmesh/data";
 import {
   DEFAULT_POLICY_TEMPLATES,
   type PolicyEffect,
   type PolicyTemplate,
 } from "./policy-default-templates.js";
 import { getDefaultEnabledTemplates } from "./policy-templates-loader.js";
+import { logActivity } from "./activity-log.js";
 
 export { DEFAULT_POLICY_TEMPLATES };
 export type { PolicyEffect, PolicyTemplate };
@@ -372,7 +373,7 @@ async function logPolicyEvaluation(
   input: PolicyEvaluationInput,
   result: PolicyEvaluationResult,
 ): Promise<void> {
-  await db.insert(activityLog).values({
+  await logActivity(db, {
     projectId: input.projectId,
     actorType: "agent",
     actorId: input.agentId,


### PR DESCRIPTION
## Summary

Part of #376.

This PR fixes a governance/audit gap in the policy evaluation path.

Policy evaluations were being written directly to `activity_log`, which bypassed the shared `logActivity()` helper. That meant policy decision rows could miss the normal attestation queueing path used for tamper-evident audit entries.

This change:

- extends `logActivity()` to accept `policyVersion` and `policyOutcome`
- promotes existing policy metadata from `details` into the top-level activity columns when present
- routes policy evaluation logging through `logActivity()` instead of direct `activity_log` inserts
- adds focused regression tests for metadata preservation and audit helper usage

## Why

The LFX roadmap in #376 calls for a tamper-evident audit log with policy metadata.

Policy evaluations are some of the most important governance events in GitMesh because they answer whether an agent action was allowed, blocked, or required approval. These rows should go through the same auditable path as other activity entries.

## Validation

Passed:

```sh
vitest run server/src/__tests__/policy-engine-audit.test.ts server/src/__tests__/activity-log.test.ts