### PR TITLE
fix: make Cursor playbook injection tests work on Windows

### DIFF
--- a/lib/adapters/cursor/src/server/execute.ts
+++ b/lib/adapters/cursor/src/server/execute.ts
@@ -127,7 +127,14 @@ export async function ensureCursorPlaybooksInjected(
     return;
   }
 
-  const linkSkill = options.linkSkill ?? ((source: string, target: string) => fs.symlink(source, target));
+  const linkSkill =
+    options.linkSkill ??
+    (async (source: string, target: string) =>
+      await fs.symlink(
+        source,
+        target,
+        process.platform === "win32" ? "junction" : undefined,
+      ));
   const allowedPlaybooks = options.role ? new Set(getPlaybooksForRole(options.role)) : null;
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;

--- a/server/src/__tests__/cursor-local-skill-injection.test.ts
+++ b/server/src/__tests__/cursor-local-skill-injection.test.ts
@@ -91,7 +91,11 @@ describe("cursor local adapter playbook injection", () => {
           if (target.endsWith(`${path.sep}fail-playbook`)) {
             throw new Error("simulated link failure");
           }
-          await fs.symlink(source, target);
+          await fs.symlink(
+            source,
+            target,
+            process.platform === "win32" ? "junction" : undefined,
+          );
         },
       },
     );


### PR DESCRIPTION
## Summary

This fixes Cursor playbook injection test failures on Windows environments by ensuring compatibility with Windows filesystem behavior (symlinks vs directory junctions).

Previously, tests assumed Unix-style symlink behavior, which could fail on Windows depending on how the filesystem represents linked directories.

## Changes

- Improve Windows compatibility for Cursor playbook injection tests
- Handle differences in filesystem link behavior between Unix and Windows
- Ensure tests pass consistently across platforms

## Testing
`pnpm test cursor-local-skill-injection`