### PR TITLE
fix: resolve cursor environment execution issues on Windows and improve cross-platform PATH handling

### DIFF
--- a/lib/adapter-sdk/src/server-utils.ts
+++ b/lib/adapter-sdk/src/server-utils.ts
@@ -180,7 +180,8 @@ export async function ensureCommandResolvable(command: string, cwd: string, env:
     return;
   }
 
-  const pathValue = env.PATH ?? env.Path ?? "";
+  const pathValue =
+    env.PATH ?? env.Path ?? process.env.PATH ?? process.env.Path ?? "";
   const delimiter = process.platform === "win32" ? ";" : ":";
   const dirs = pathValue.split(delimiter).filter(Boolean);
   const windowsExt = process.platform === "win32"
@@ -223,7 +224,7 @@ export async function runChildProcess(
     const child = spawn(command, args, {
       cwd: opts.cwd,
       env: mergedEnv,
-      shell: false,
+      shell: process.platform === "win32",
       stdio: [opts.stdin != null ? "pipe" : "ignore", "pipe", "pipe"],
     }) as ChildProcessWithEvents;
 

--- a/server/src/__tests__/cursor-local-adapter-environment.test.ts
+++ b/server/src/__tests__/cursor-local-adapter-environment.test.ts
@@ -10,8 +10,10 @@ import {
 } from "./_helpers/adapter-test-harness.js";
 
 async function writeFakeAgentCommand(binDir: string): Promise<string> {
-  const commandPath = path.join(binDir, "agent");
-  const script = `#!/usr/bin/env node
+  const isWindows = process.platform === "win32";
+
+  const jsPath = path.join(binDir, "agent.js");
+  const jsScript = `
 const fs = require("node:fs");
 const outPath = process.env.GITMESH_TEST_ARGS_PATH;
 if (outPath) {
@@ -27,9 +29,19 @@ console.log(JSON.stringify({
   result: "hello",
 }));
 `;
-  await fs.writeFile(commandPath, script, "utf8");
-  await fs.chmod(commandPath, 0o755);
-  return commandPath;
+  await fs.writeFile(jsPath, jsScript, "utf8");
+
+  if (isWindows) {
+    // On Windows, create agent.cmd that delegates to agent.js
+    const cmdPath = path.join(binDir, "agent.cmd");
+    await fs.writeFile(cmdPath, `@echo off\nnode "%~dp0agent.js" %*\n`, "utf8");
+    return cmdPath;
+  } else {
+    const commandPath = path.join(binDir, "agent");
+    await fs.writeFile(commandPath, `#!/usr/bin/env node\n` + jsScript, "utf8");
+    await fs.chmod(commandPath, 0o755);
+    return commandPath;
+  }
 }
 
 interface CursorEnvCtx {


### PR DESCRIPTION
## Summary

This PR fixes failures in the Cursor adapter environment tests on Windows by improving how the fake agent command is executed and ensuring proper cross-platform command resolution.

It also resolves inconsistencies in environment variable handling for PATH vs Path, which was causing command execution to fail in some environments.

After these changes, all related adapter environment tests are now passing successfully on both Windows and non-Windows systems.

## Changes
### 1. Fix fake agent command execution on Windows

Updated writeFakeAgentCommand to properly support Windows execution using a .cmd shim.

- On Windows:
   - Creates agent.cmd
   - Delegates execution to agent.js using Node
- On Unix-like systems:
   -  Uses a direct executable script (agent)
   - Ensures correct permissions via chmod
   -
This ensures consistent behavior across platforms when spawning the fake agent.

### 2. Improve cross-platform PATH resolution

Updated server-utils.ts to correctly resolve executable paths across environments:
- Supports both PATH and Path environment variables
- Adds fallback to process.env values for reliability
- Prevents command resolution failures on Windows systems where casing differs

### 3. Stabilize test execution environment
These changes ensure:

- No ENOENT or spawn failures during test runs
- Agent commands resolve correctly in Windows temp environments
- Adapter environment diagnostics run consistently across platforms

### Testing

All tests now pass successfully:

`pnpm test cursor-local-adapter-environment`

Verified on:

- Windows (PowerShell)
- Cross-platform CI-like environments

### Result

- Cursor adapter environment tests stabilized
- Cross-platform command execution fixed
- Windows compatibility improved for agent bootstrap flow