### PR TITLE
chore: Standardize detection mechanisms for all coding agents

### DIFF
--- a/.changeset/detect-fs-extraction.md
+++ b/.changeset/detect-fs-extraction.md
@@ -2,4 +2,4 @@
 "@gitmesh/workspace-adapters": patch
 ---
 
-Extract the filesystem plumbing duplicated between the claude-code and codex detectors into a shared internal module (`src/detect-fs.ts`) and their duplicated test wiring into a test-only harness (`src/detect-test-utils.ts`), ahead of the T1.3+ detectors. Internal refactor: no behavior, output, fixture, or public API changes.
+Extract the filesystem plumbing duplicated between the claude-code and codex detectors into a shared internal module (`src/detect-fs.ts`) and their duplicated test wiring into a test-only harness (`src/detect-test-utils.ts`), ahead of the T1.3+ detectors. Internal refactor: no output, fixture, or public API changes.

--- a/.changeset/detect-fs-extraction.md
+++ b/.changeset/detect-fs-extraction.md
@@ -1,0 +1,5 @@
+---
+"@gitmesh/workspace-adapters": patch
+---
+
+Extract the filesystem plumbing duplicated between the claude-code and codex detectors into a shared internal module (`src/detect-fs.ts`) and their duplicated test wiring into a test-only harness (`src/detect-test-utils.ts`), ahead of the T1.3+ detectors. Internal refactor: no behavior, output, fixture, or public API changes.

--- a/lib/workspace-adapters/src/claude-code/detect.test.ts
+++ b/lib/workspace-adapters/src/claude-code/detect.test.ts
@@ -1,31 +1,17 @@
+import { chmodSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
 import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
-import { assertGoldenCase, listGoldenCases } from "../golden.js";
+  describeDetectorGoldens,
+  loadCaseOptions,
+  symlinkSupport,
+  useTempDirs,
+} from "../detect-test-utils.js";
 import type { RepoContext } from "../types.js";
-import {
-  claudeCodeAdapter,
-  defaultManagedSettingsPaths,
-  detect,
-  type ClaudeCodeArtifact,
-} from "./index.js";
-
-const fixturesRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../fixtures");
+import { claudeCodeAdapter, defaultManagedSettingsPaths, detect } from "./index.js";
 
 /**
- * Per-case detector options stored in `<case>/options.json` (sibling of
- * `input-repo/`, so it is never part of the scanned tree). Relative paths
+ * Per-case detector options stored in `<case>/options.json`. Relative paths
  * resolve against the case directory.
  */
 interface CaseOptions {
@@ -34,11 +20,8 @@ interface CaseOptions {
   managedSettingsPaths?: string[];
 }
 
-function contextFor(caseDir: string, inputRepoDir: string): RepoContext {
-  const optionsPath = join(caseDir, "options.json");
-  const options: CaseOptions = existsSync(optionsPath)
-    ? (JSON.parse(readFileSync(optionsPath, "utf8")) as CaseOptions)
-    : {};
+describeDetectorGoldens(claudeCodeAdapter, "T1.1", (caseDir, inputRepoDir) => {
+  const options = loadCaseOptions<CaseOptions>(caseDir);
   return {
     rootDir: inputRepoDir,
     userScope: options.userScope ?? false,
@@ -48,90 +31,15 @@ function contextFor(caseDir: string, inputRepoDir: string): RepoContext {
       join(caseDir, p),
     ),
   };
-}
-
-function serialize(artifacts: readonly ClaudeCodeArtifact[]): string {
-  return `${JSON.stringify(artifacts, null, 2)}\n`;
-}
-
-describe("claude-code golden fixtures", () => {
-  const goldenCases = listGoldenCases(fixturesRoot).filter(
-    (c) => c.adapter === "claude-code",
-  );
-
-  it("ships at least 3 cases including the negative one (T1.1 AC)", () => {
-    expect(goldenCases.length).toBeGreaterThanOrEqual(3);
-    expect(goldenCases.map((c) => c.name)).toContain("no-artifacts");
-  });
-
-  it("declares its fixtures on the adapter, matching the on-disk cases", () => {
-    expect(claudeCodeAdapter.fixtures.map((f) => f.name)).toEqual(
-      goldenCases.map((c) => c.name),
-    );
-  });
-
-  for (const goldenCase of listGoldenCases(fixturesRoot).filter(
-    (c) => c.adapter === "claude-code",
-  )) {
-    it(`matches ${goldenCase.name} byte-exactly`, async () => {
-      await assertGoldenCase(goldenCase, (inputRepoDir) => [
-        {
-          path: "detected.json",
-          content: serialize(detect(contextFor(goldenCase.dir, inputRepoDir))),
-        },
-      ]);
-    });
-  }
 });
 
-const tempDirs: string[] = [];
-
-afterEach(() => {
-  while (tempDirs.length > 0) {
-    rmSync(tempDirs.pop()!, { recursive: true, force: true });
-  }
-});
+const temp = useTempDirs();
 
 /** Creates a temp repo from `files` and returns a probe-free context for it. */
 function makeRepo(files: Record<string, string>): { root: string; repo: RepoContext } {
-  const root = mkdtempSync(join(tmpdir(), "gitmesh-claude-detect-"));
-  tempDirs.push(root);
-  for (const [path, content] of Object.entries(files)) {
-    mkdirSync(join(root, dirname(path)), { recursive: true });
-    writeFileSync(join(root, path), content);
-  }
+  const root = temp.makeRepo("gitmesh-claude-detect-", files);
   return { root, repo: { rootDir: root, managedSettingsPaths: [] } };
 }
-
-/**
- * File symlinks need Developer Mode or admin rights on Windows; directory
- * links are created as junctions, which work unprivileged. Probe once and
- * skip symlink tests where the platform cannot create them.
- */
-const symlinkSupport = (() => {
-  const dir = mkdtempSync(join(tmpdir(), "gitmesh-symlink-probe-"));
-  let file = false;
-  let directory = false;
-  try {
-    writeFileSync(join(dir, "target.txt"), "x");
-    try {
-      symlinkSync("target.txt", join(dir, "file-link"));
-      file = true;
-    } catch {
-      /* unsupported */
-    }
-    mkdirSync(join(dir, "target-dir"));
-    try {
-      symlinkSync(join(dir, "target-dir"), join(dir, "dir-link"), "junction");
-      directory = true;
-    } catch {
-      /* unsupported */
-    }
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-  return { file, directory };
-})();
 
 /** Creates a directory symlink portably (junction on Windows, symlink elsewhere). */
 function symlinkDir(target: string, linkPath: string): void {
@@ -169,8 +77,7 @@ describe("claude-code detect()", () => {
   });
 
   it("reports user-scope memory only when userScope is set", () => {
-    const home = mkdtempSync(join(tmpdir(), "gitmesh-claude-home-"));
-    tempDirs.push(home);
+    const home = temp.makeDir("gitmesh-claude-home-");
     mkdirSync(join(home, ".claude"), { recursive: true });
     writeFileSync(join(home, ".claude", "CLAUDE.md"), "# personal\n");
     const { root } = makeRepo({ "CLAUDE.md": "repo\n" });
@@ -192,8 +99,7 @@ describe("claude-code detect()", () => {
   });
 
   it("probes managed settings by presence only, reporting basenames", () => {
-    const managed = mkdtempSync(join(tmpdir(), "gitmesh-claude-managed-"));
-    tempDirs.push(managed);
+    const managed = temp.makeDir("gitmesh-claude-managed-");
     writeFileSync(join(managed, "managed-settings.json"), "{}\n");
     mkdirSync(join(managed, "managed-settings.d"));
     writeFileSync(join(managed, "managed-settings.d", "00.json"), "{}\n");

--- a/lib/workspace-adapters/src/claude-code/detect.ts
+++ b/lib/workspace-adapters/src/claude-code/detect.ts
@@ -84,11 +84,10 @@ export function detect(repo: RepoContext): ClaudeCodeArtifact[] {
     "",
     new Set(),
     (name) => !INSTRUCTION_WALK_EXCLUDES.has(name),
+    (name) => name === "CLAUDE.md" || name === "CLAUDE.local.md",
     (name, rel, info) => {
-      if (name === "CLAUDE.md" || name === "CLAUDE.local.md") {
-        const scope = name === "CLAUDE.md" ? "project" : "local";
-        artifacts.push(makeArtifact(rel, "instructions", scope, info));
-      }
+      const scope = name === "CLAUDE.md" ? "project" : "local";
+      artifacts.push(makeArtifact(rel, "instructions", scope, info));
     },
   );
 
@@ -148,11 +147,16 @@ function collectMarkdownTree(
   kind: ClaudeCodeArtifactKind,
   out: ClaudeCodeArtifact[],
 ): void {
-  walk(join(root, relBase), relBase, new Set(), () => true, (name, rel, info) => {
-    if (name.endsWith(".md")) {
+  walk(
+    join(root, relBase),
+    relBase,
+    new Set(),
+    () => true,
+    (name) => name.endsWith(".md"),
+    (name, rel, info) => {
       out.push(makeArtifact(rel, kind, "project", info));
-    }
-  });
+    },
+  );
 }
 
 /**

--- a/lib/workspace-adapters/src/claude-code/detect.ts
+++ b/lib/workspace-adapters/src/claude-code/detect.ts
@@ -1,14 +1,15 @@
-import {
-  lstatSync,
-  readdirSync,
-  readlinkSync,
-  realpathSync,
-  statSync,
-  type Dirent,
-  type Stats,
-} from "node:fs";
 import { homedir } from "node:os";
 import { join, posix, win32 } from "node:path";
+import {
+  compareArtifacts,
+  inspectFile,
+  isTraversableDir,
+  lastSegment,
+  makeArtifact,
+  safeStat,
+  sortedEntries,
+  walk,
+} from "../detect-fs.js";
 import type { DetectedArtifact, RepoContext } from "../types.js";
 
 /**
@@ -78,7 +79,18 @@ export function detect(repo: RepoContext): ClaudeCodeArtifact[] {
   const artifacts: ClaudeCodeArtifact[] = [];
 
   // 1. CLAUDE.md / CLAUDE.local.md hierarchy: repo root + every subdirectory.
-  collectInstructions(root, "", artifacts, new Set());
+  walk(
+    root,
+    "",
+    new Set(),
+    (name) => !INSTRUCTION_WALK_EXCLUDES.has(name),
+    (name, rel, info) => {
+      if (name === "CLAUDE.md" || name === "CLAUDE.local.md") {
+        const scope = name === "CLAUDE.md" ? "project" : "local";
+        artifacts.push(makeArtifact(rel, "instructions", scope, info));
+      }
+    },
+  );
 
   // 2. `.claude/` surface. Settings are resolved from the git root only
   //    (Claude Code v2.1.211+ semantics; callers pass that root as rootDir),
@@ -115,28 +127,6 @@ export function detect(repo: RepoContext): ClaudeCodeArtifact[] {
   return dedupe(artifacts).sort(compareArtifacts);
 }
 
-/** Symlink details of an inventoried file; empty for a regular file. */
-interface FileInfo {
-  symlinkTarget?: string;
-  broken?: boolean;
-}
-
-function makeArtifact(
-  path: string,
-  kind: ClaudeCodeArtifactKind,
-  scope: ClaudeCodeArtifact["scope"],
-  info: FileInfo = {},
-): ClaudeCodeArtifact {
-  const artifact: ClaudeCodeArtifact = { path, kind, scope };
-  if (info.symlinkTarget !== undefined) {
-    artifact.symlinkTarget = info.symlinkTarget;
-  }
-  if (info.broken) {
-    artifact.broken = true;
-  }
-  return artifact;
-}
-
 /** Inventories `relPath` under `root` when it holds a file (or file symlink). */
 function addFile(
   out: ClaudeCodeArtifact[],
@@ -151,135 +141,6 @@ function addFile(
   }
 }
 
-/**
- * `stat` (follows symlinks) that never throws: `undefined` for any unreachable
- * path — missing (`ENOENT`), a symlink cycle (`ELOOP`), or one we lack
- * permission to resolve (`EACCES`). `throwIfNoEntry` suppresses only `ENOENT`,
- * so the `try` covers the rest; a doctor scan must not abort on one bad entry.
- */
-function safeStat(absPath: string): Stats | undefined {
-  try {
-    return statSync(absPath, { throwIfNoEntry: false });
-  } catch {
-    return undefined;
-  }
-}
-
-/** `lstat` (does not follow symlinks) that never throws; see {@link safeStat}. */
-function safeLstat(absPath: string): Stats | undefined {
-  try {
-    return lstatSync(absPath, { throwIfNoEntry: false });
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Inspects one path expected to hold a regular file. Returns `null` when it
- * does not exist or is a directory; symlinks are reported with their literal
- * target, flagged broken when they do not resolve to a file.
- */
-function inspectFile(absPath: string): FileInfo | null {
-  const stats = safeLstat(absPath);
-  if (stats === undefined) {
-    return null;
-  }
-  if (stats.isSymbolicLink()) {
-    return symlinkInfo(absPath);
-  }
-  return stats.isFile() ? {} : null;
-}
-
-/** Like {@link inspectFile}, reusing the `Dirent` from a directory listing. */
-function fileInfoFromEntry(entry: Dirent, absPath: string): FileInfo | null {
-  if (entry.isSymbolicLink()) {
-    return symlinkInfo(absPath);
-  }
-  return entry.isFile() ? {} : null;
-}
-
-function symlinkInfo(absPath: string): FileInfo {
-  let symlinkTarget: string;
-  try {
-    symlinkTarget = readlinkSync(absPath).replaceAll("\\", "/");
-  } catch {
-    // A symlink we cannot even read (e.g. permission denied): flag it broken
-    // rather than aborting the scan.
-    return { broken: true };
-  }
-  const resolved = safeStat(absPath);
-  return resolved?.isFile() ? { symlinkTarget } : { symlinkTarget, broken: true };
-}
-
-/** True for directories, including symlinks that resolve to directories. */
-function isTraversableDir(entry: Dirent, absPath: string): boolean {
-  if (entry.isDirectory()) {
-    return true;
-  }
-  if (!entry.isSymbolicLink()) {
-    return false;
-  }
-  return safeStat(absPath)?.isDirectory() ?? false;
-}
-
-/**
- * Marks a directory as visited by real path; returns false when it was seen
- * before (symlink cycle or an aliased tree) so walks terminate and each real
- * directory is inventoried exactly once.
- */
-function markVisited(absDir: string, visited: Set<string>): boolean {
-  let real: string;
-  try {
-    real = realpathSync(absDir);
-  } catch {
-    return false;
-  }
-  if (visited.has(real)) {
-    return false;
-  }
-  visited.add(real);
-  return true;
-}
-
-function sortedEntries(absDir: string): Dirent[] {
-  let entries: Dirent[];
-  try {
-    entries = readdirSync(absDir, { withFileTypes: true });
-  } catch {
-    // Unreadable directory (permissions, a race, a special file): contribute
-    // nothing rather than aborting the whole inventory.
-    return [];
-  }
-  return entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-}
-
-/** Walks the repo for CLAUDE.md (project) and CLAUDE.local.md (local) files. */
-function collectInstructions(
-  absDir: string,
-  relDir: string,
-  out: ClaudeCodeArtifact[],
-  visited: Set<string>,
-): void {
-  if (!markVisited(absDir, visited)) {
-    return;
-  }
-  for (const entry of sortedEntries(absDir)) {
-    const abs = join(absDir, entry.name);
-    const rel = relDir === "" ? entry.name : `${relDir}/${entry.name}`;
-    if (isTraversableDir(entry, abs)) {
-      if (!INSTRUCTION_WALK_EXCLUDES.has(entry.name)) {
-        collectInstructions(abs, rel, out, visited);
-      }
-    } else if (entry.name === "CLAUDE.md" || entry.name === "CLAUDE.local.md") {
-      const info = fileInfoFromEntry(entry, abs);
-      if (info) {
-        const scope = entry.name === "CLAUDE.md" ? "project" : "local";
-        out.push(makeArtifact(rel, "instructions", scope, info));
-      }
-    }
-  }
-}
-
 /** Recursively inventories every `*.md` file under `root`/`relBase`. */
 function collectMarkdownTree(
   root: string,
@@ -287,34 +148,11 @@ function collectMarkdownTree(
   kind: ClaudeCodeArtifactKind,
   out: ClaudeCodeArtifact[],
 ): void {
-  if (!isDirectory(join(root, relBase))) {
-    return;
-  }
-  walkMarkdown(join(root, relBase), relBase, kind, out, new Set());
-}
-
-function walkMarkdown(
-  absDir: string,
-  relDir: string,
-  kind: ClaudeCodeArtifactKind,
-  out: ClaudeCodeArtifact[],
-  visited: Set<string>,
-): void {
-  if (!markVisited(absDir, visited)) {
-    return;
-  }
-  for (const entry of sortedEntries(absDir)) {
-    const abs = join(absDir, entry.name);
-    const rel = `${relDir}/${entry.name}`;
-    if (isTraversableDir(entry, abs)) {
-      walkMarkdown(abs, rel, kind, out, visited);
-    } else if (entry.name.endsWith(".md")) {
-      const info = fileInfoFromEntry(entry, abs);
-      if (info) {
-        out.push(makeArtifact(rel, kind, "project", info));
-      }
+  walk(join(root, relBase), relBase, new Set(), () => true, (name, rel, info) => {
+    if (name.endsWith(".md")) {
+      out.push(makeArtifact(rel, kind, "project", info));
     }
-  }
+  });
 }
 
 /**
@@ -323,9 +161,6 @@ function walkMarkdown(
  */
 function collectSkills(root: string, out: ClaudeCodeArtifact[]): void {
   const base = join(root, ".claude", "skills");
-  if (!isDirectory(base)) {
-    return;
-  }
   for (const entry of sortedEntries(base)) {
     if (!isTraversableDir(entry, join(base, entry.name))) {
       continue;
@@ -336,16 +171,6 @@ function collectSkills(root: string, out: ClaudeCodeArtifact[]): void {
       out.push(makeArtifact(rel, "skill", "project", info));
     }
   }
-}
-
-function isDirectory(absPath: string): boolean {
-  return safeStat(absPath)?.isDirectory() ?? false;
-}
-
-/** Final path segment, tolerant of either separator (managed probe display). */
-function lastSegment(path: string): string {
-  const segments = path.split(/[\\/]/).filter((segment) => segment !== "");
-  return segments[segments.length - 1] ?? path;
 }
 
 /** Managed probes may alias; everything else is unique by construction. */
@@ -359,15 +184,4 @@ function dedupe(artifacts: ClaudeCodeArtifact[]): ClaudeCodeArtifact[] {
     seen.add(key);
     return true;
   });
-}
-
-/** Deterministic code-unit ordering by path, then kind, then scope. */
-function compareArtifacts(a: DetectedArtifact, b: DetectedArtifact): number {
-  if (a.path !== b.path) {
-    return a.path < b.path ? -1 : 1;
-  }
-  if (a.kind !== b.kind) {
-    return a.kind < b.kind ? -1 : 1;
-  }
-  return a.scope < b.scope ? -1 : a.scope > b.scope ? 1 : 0;
 }

--- a/lib/workspace-adapters/src/codex/detect.test.ts
+++ b/lib/workspace-adapters/src/codex/detect.test.ts
@@ -1,26 +1,14 @@
+import { symlinkSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
 import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
-import { assertGoldenCase, listGoldenCases } from "../golden.js";
+  describeDetectorGoldens,
+  loadCaseOptions,
+  symlinkSupport,
+  useTempDirs,
+} from "../detect-test-utils.js";
 import type { RepoContext } from "../types.js";
-import {
-  codexAdapter,
-  defaultRequirementsTomlPaths,
-  detect,
-  type CodexArtifact,
-} from "./index.js";
-
-const fixturesRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../fixtures");
+import { codexAdapter, defaultRequirementsTomlPaths, detect } from "./index.js";
 
 /**
  * Per-case options in `<case>/options.json` (sibling of `input-repo/`).
@@ -35,11 +23,8 @@ interface CaseOptions {
   requirementsTomlPaths?: string[];
 }
 
-function contextFor(caseDir: string, inputRepoDir: string): RepoContext {
-  const optionsPath = join(caseDir, "options.json");
-  const options: CaseOptions = existsSync(optionsPath)
-    ? (JSON.parse(readFileSync(optionsPath, "utf8")) as CaseOptions)
-    : {};
+describeDetectorGoldens(codexAdapter, "T1.2", (caseDir, inputRepoDir) => {
+  const options = loadCaseOptions<CaseOptions>(caseDir);
   return {
     rootDir: inputRepoDir,
     userScope: options.userScope ?? false,
@@ -52,69 +37,15 @@ function contextFor(caseDir: string, inputRepoDir: string): RepoContext {
       join(caseDir, p),
     ),
   };
-}
-
-function serialize(artifacts: readonly CodexArtifact[]): string {
-  return `${JSON.stringify(artifacts, null, 2)}\n`;
-}
-
-describe("codex golden fixtures", () => {
-  const goldenCases = listGoldenCases(fixturesRoot).filter((c) => c.adapter === "codex");
-
-  it("ships at least 3 cases including the negative one (T1.2 AC)", () => {
-    expect(goldenCases.length).toBeGreaterThanOrEqual(3);
-    expect(goldenCases.map((c) => c.name)).toContain("no-artifacts");
-    expect(codexAdapter.fixtures.map((f) => f.name)).toEqual(
-      goldenCases.map((c) => c.name),
-    );
-  });
-
-  for (const goldenCase of listGoldenCases(fixturesRoot).filter(
-    (c) => c.adapter === "codex",
-  )) {
-    it(`matches ${goldenCase.name} byte-exactly`, async () => {
-      await assertGoldenCase(goldenCase, (inputRepoDir) => [
-        {
-          path: "detected.json",
-          content: serialize(detect(contextFor(goldenCase.dir, inputRepoDir))),
-        },
-      ]);
-    });
-  }
 });
 
-const tempDirs: string[] = [];
-
-afterEach(() => {
-  while (tempDirs.length > 0) {
-    rmSync(tempDirs.pop()!, { recursive: true, force: true });
-  }
-});
+const temp = useTempDirs();
 
 /** Creates a temp repo from `files` and returns a probe-free context for it. */
 function makeRepo(files: Record<string, string>): { root: string; repo: RepoContext } {
-  const root = mkdtempSync(join(tmpdir(), "gitmesh-codex-detect-"));
-  tempDirs.push(root);
-  for (const [path, content] of Object.entries(files)) {
-    mkdirSync(join(root, dirname(path)), { recursive: true });
-    writeFileSync(join(root, path), content);
-  }
+  const root = temp.makeRepo("gitmesh-codex-detect-", files);
   return { root, repo: { rootDir: root, env: {}, requirementsTomlPaths: [] } };
 }
-
-/** File symlinks need Developer Mode/admin on Windows; probe and skip if absent. */
-const fileSymlinkSupport = (() => {
-  const dir = mkdtempSync(join(tmpdir(), "gitmesh-symlink-probe-"));
-  try {
-    writeFileSync(join(dir, "target.txt"), "x");
-    symlinkSync("target.txt", join(dir, "file-link"));
-    return true;
-  } catch {
-    return false;
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-})();
 
 describe("codex detect()", () => {
   it("reports a CODEX_HOME hint when set — presence only, never the value", () => {
@@ -141,7 +72,7 @@ describe("codex detect()", () => {
     ]);
   });
 
-  it.skipIf(!fileSymlinkSupport)(
+  it.skipIf(!symlinkSupport.file)(
     "inventories a symlinked AGENTS.md with its literal target",
     () => {
       const { root, repo } = makeRepo({ "CLAUDE.md": "shared\n" });
@@ -157,7 +88,7 @@ describe("codex detect()", () => {
     },
   );
 
-  it.skipIf(!fileSymlinkSupport)("flags a dangling symlink as broken", () => {
+  it.skipIf(!symlinkSupport.file)("flags a dangling symlink as broken", () => {
     const { root, repo } = makeRepo({});
     symlinkSync("missing.md", join(root, "AGENTS.md"), "file");
     expect(detect(repo)).toEqual([

--- a/lib/workspace-adapters/src/codex/detect.ts
+++ b/lib/workspace-adapters/src/codex/detect.ts
@@ -1,14 +1,16 @@
-import {
-  lstatSync,
-  readdirSync,
-  readlinkSync,
-  realpathSync,
-  statSync,
-  type Dirent,
-  type Stats,
-} from "node:fs";
 import { homedir } from "node:os";
 import { join, posix, win32 } from "node:path";
+import {
+  compareArtifacts,
+  fileInfoFromEntry,
+  inspectFile,
+  isTraversableDir,
+  lastSegment,
+  makeArtifact,
+  safeStat,
+  sortedEntries,
+  walk,
+} from "../detect-fs.js";
 import type { DetectedArtifact, RepoContext } from "../types.js";
 
 /**
@@ -133,7 +135,7 @@ export function detect(repo: RepoContext): CodexArtifact[] {
   const seen = new Set<string>();
   for (const probe of repo.requirementsTomlPaths ??
     defaultRequirementsTomlPaths(process.platform, env)) {
-    const name = win32.basename(probe);
+    const name = lastSegment(probe);
     if (!seen.has(name) && safeStat(probe) !== undefined) {
       seen.add(name);
       out.push(makeArtifact(name, "requirements", "managed"));
@@ -141,128 +143,4 @@ export function detect(repo: RepoContext): CodexArtifact[] {
   }
 
   return out.sort(compareArtifacts);
-}
-
-interface FileInfo {
-  symlinkTarget?: string;
-  broken?: boolean;
-}
-
-function makeArtifact(
-  path: string,
-  kind: CodexArtifactKind,
-  scope: CodexArtifact["scope"],
-  info: FileInfo = {},
-): CodexArtifact {
-  const artifact: CodexArtifact = { path, kind, scope };
-  if (info.symlinkTarget !== undefined) {
-    artifact.symlinkTarget = info.symlinkTarget;
-  }
-  if (info.broken) {
-    artifact.broken = true;
-  }
-  return artifact;
-}
-
-function safeStat(absPath: string): Stats | undefined {
-  try {
-    return statSync(absPath, { throwIfNoEntry: false });
-  } catch {
-    return undefined;
-  }
-}
-
-function inspectFile(absPath: string): FileInfo | null {
-  let stats: Stats | undefined;
-  try {
-    stats = lstatSync(absPath, { throwIfNoEntry: false });
-  } catch {
-    return null;
-  }
-  if (stats === undefined) {
-    return null;
-  }
-  if (stats.isSymbolicLink()) {
-    return symlinkInfo(absPath);
-  }
-  return stats.isFile() ? {} : null;
-}
-
-function fileInfoFromEntry(entry: Dirent, absPath: string): FileInfo | null {
-  if (entry.isSymbolicLink()) {
-    return symlinkInfo(absPath);
-  }
-  return entry.isFile() ? {} : null;
-}
-
-function symlinkInfo(absPath: string): FileInfo {
-  let symlinkTarget: string;
-  try {
-    symlinkTarget = readlinkSync(absPath).replaceAll("\\", "/");
-  } catch {
-    return { broken: true };
-  }
-  return safeStat(absPath)?.isFile() ? { symlinkTarget } : { symlinkTarget, broken: true };
-}
-
-function isTraversableDir(entry: Dirent, absPath: string): boolean {
-  if (entry.isDirectory()) {
-    return true;
-  }
-  return entry.isSymbolicLink() && (safeStat(absPath)?.isDirectory() ?? false);
-}
-
-/** Sorted listing; an unreadable or missing directory contributes nothing. */
-function sortedEntries(absDir: string): Dirent[] {
-  let entries: Dirent[];
-  try {
-    entries = readdirSync(absDir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  return entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-}
-
-/** Cycle-safe recursive walk (visited real paths); `recurse` gates descent. */
-function walk(
-  absDir: string,
-  relDir: string,
-  visited: Set<string>,
-  recurse: (dirName: string) => boolean,
-  onFile: (name: string, rel: string, info: FileInfo) => void,
-): void {
-  let real: string;
-  try {
-    real = realpathSync(absDir);
-  } catch {
-    return;
-  }
-  if (visited.has(real)) {
-    return;
-  }
-  visited.add(real);
-  for (const entry of sortedEntries(absDir)) {
-    const abs = join(absDir, entry.name);
-    const rel = relDir === "" ? entry.name : `${relDir}/${entry.name}`;
-    if (isTraversableDir(entry, abs)) {
-      if (recurse(entry.name)) {
-        walk(abs, rel, visited, recurse, onFile);
-      }
-    } else {
-      const info = fileInfoFromEntry(entry, abs);
-      if (info) {
-        onFile(entry.name, rel, info);
-      }
-    }
-  }
-}
-
-function compareArtifacts(a: DetectedArtifact, b: DetectedArtifact): number {
-  if (a.path !== b.path) {
-    return a.path < b.path ? -1 : 1;
-  }
-  if (a.kind !== b.kind) {
-    return a.kind < b.kind ? -1 : 1;
-  }
-  return a.scope < b.scope ? -1 : a.scope > b.scope ? 1 : 0;
 }

--- a/lib/workspace-adapters/src/codex/detect.ts
+++ b/lib/workspace-adapters/src/codex/detect.ts
@@ -70,11 +70,16 @@ export function detect(repo: RepoContext): CodexArtifact[] {
   const env = repo.env ?? process.env;
   const out: CodexArtifact[] = [];
 
-  walk(root, "", new Set(), (dir) => !WALK_EXCLUDES.has(dir), (name, rel, info) => {
-    if (name === "AGENTS.md") {
+  walk(
+    root,
+    "",
+    new Set(),
+    (dir) => !WALK_EXCLUDES.has(dir),
+    (name) => name === "AGENTS.md",
+    (name, rel, info) => {
       out.push(makeArtifact(rel, "instructions", "project", info));
-    }
-  });
+    },
+  );
 
   const configInfo = inspectFile(join(root, ".codex", "config.toml"));
   if (configInfo) {
@@ -96,11 +101,16 @@ export function detect(repo: RepoContext): CodexArtifact[] {
 
   // Execpolicy `.rules`: §4.3 fixes no location, so scan `.codex/` only —
   // a repo-wide sweep would false-positive on unrelated `.rules` files.
-  walk(join(root, ".codex"), ".codex", new Set(), () => true, (name, rel, info) => {
-    if (name.endsWith(".rules")) {
+  walk(
+    join(root, ".codex"),
+    ".codex",
+    new Set(),
+    () => true,
+    (name) => name.endsWith(".rules"),
+    (name, rel, info) => {
       out.push(makeArtifact(rel, "execpolicy", "project", info));
-    }
-  });
+    },
+  );
 
   // Skills: one `.agents/skills/<name>/SKILL.md` manifest per skill.
   const skillsBase = join(root, ".agents", "skills");

--- a/lib/workspace-adapters/src/detect-fs.ts
+++ b/lib/workspace-adapters/src/detect-fs.ts
@@ -126,14 +126,17 @@ export function sortedEntries(absDir: string): Dirent[] {
  * Cycle-safe recursive walk. Directories are marked visited by real path, so
  * symlink cycles and aliased trees terminate and each real directory is
  * inventoried exactly once; `recurse` gates descent by directory name;
- * `onFile` receives each file (or file symlink) with its POSIX-style path
- * relative to the walk root.
+ * `fileFilter` gates which file names are inspected at all — inspecting a
+ * symlink costs `readlink` + `stat`, so filtering happens before inspection,
+ * not in `onFile`; `onFile` receives each matching file (or file symlink)
+ * with its POSIX-style path relative to the walk root.
  */
 export function walk(
   absDir: string,
   relDir: string,
   visited: Set<string>,
   recurse: (dirName: string) => boolean,
+  fileFilter: (name: string) => boolean,
   onFile: (name: string, rel: string, info: FileInfo) => void,
 ): void {
   let real: string;
@@ -151,9 +154,9 @@ export function walk(
     const rel = relDir === "" ? entry.name : `${relDir}/${entry.name}`;
     if (isTraversableDir(entry, abs)) {
       if (recurse(entry.name)) {
-        walk(abs, rel, visited, recurse, onFile);
+        walk(abs, rel, visited, recurse, fileFilter, onFile);
       }
-    } else {
+    } else if (fileFilter(entry.name)) {
       const info = fileInfoFromEntry(entry, abs);
       if (info) {
         onFile(entry.name, rel, info);

--- a/lib/workspace-adapters/src/detect-fs.ts
+++ b/lib/workspace-adapters/src/detect-fs.ts
@@ -1,0 +1,183 @@
+import {
+  lstatSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  statSync,
+  type Dirent,
+  type Stats,
+} from "node:fs";
+import { join, win32 } from "node:path";
+import type { ArtifactScope, DetectedArtifact } from "./types.js";
+
+/**
+ * Filesystem plumbing shared by the detectors (extracted from T1.1/T1.2
+ * before T1.3 adds a third copy). Everything here upholds the detector
+ * guarantees: pure, read-only, deterministic sorted output, symlink-aware
+ * (literal targets, never resolved away — pivot.md §10.4), cycle-safe, and
+ * filesystem errors contained — an unreadable directory or a broken symlink
+ * skips or flags the entry, never aborts, so a doctor scan survives any
+ * repository.
+ */
+
+/** Symlink details of an inventoried file; empty for a regular file. */
+export interface FileInfo {
+  symlinkTarget?: string;
+  broken?: boolean;
+}
+
+/** Builds one artifact, attaching symlink details only when present. */
+export function makeArtifact<K extends string>(
+  path: string,
+  kind: K,
+  scope: ArtifactScope,
+  info: FileInfo = {},
+): DetectedArtifact & { kind: K } {
+  const artifact: DetectedArtifact & { kind: K } = { path, kind, scope };
+  if (info.symlinkTarget !== undefined) {
+    artifact.symlinkTarget = info.symlinkTarget;
+  }
+  if (info.broken) {
+    artifact.broken = true;
+  }
+  return artifact;
+}
+
+/**
+ * `stat` (follows symlinks) that never throws: `undefined` for any unreachable
+ * path — missing (`ENOENT`), a symlink cycle (`ELOOP`), or one we lack
+ * permission to resolve (`EACCES`). `throwIfNoEntry` suppresses only `ENOENT`,
+ * so the `try` covers the rest; a doctor scan must not abort on one bad entry.
+ */
+export function safeStat(absPath: string): Stats | undefined {
+  try {
+    return statSync(absPath, { throwIfNoEntry: false });
+  } catch {
+    return undefined;
+  }
+}
+
+/** `lstat` (does not follow symlinks) that never throws; see {@link safeStat}. */
+export function safeLstat(absPath: string): Stats | undefined {
+  try {
+    return lstatSync(absPath, { throwIfNoEntry: false });
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Inspects one path expected to hold a regular file. Returns `null` when it
+ * does not exist or is a directory; symlinks are reported with their literal
+ * target, flagged broken when they do not resolve to a file.
+ */
+export function inspectFile(absPath: string): FileInfo | null {
+  const stats = safeLstat(absPath);
+  if (stats === undefined) {
+    return null;
+  }
+  if (stats.isSymbolicLink()) {
+    return symlinkInfo(absPath);
+  }
+  return stats.isFile() ? {} : null;
+}
+
+/** Like {@link inspectFile}, reusing the `Dirent` from a directory listing. */
+export function fileInfoFromEntry(entry: Dirent, absPath: string): FileInfo | null {
+  if (entry.isSymbolicLink()) {
+    return symlinkInfo(absPath);
+  }
+  return entry.isFile() ? {} : null;
+}
+
+export function symlinkInfo(absPath: string): FileInfo {
+  let symlinkTarget: string;
+  try {
+    symlinkTarget = readlinkSync(absPath).replaceAll("\\", "/");
+  } catch {
+    // A symlink we cannot even read (e.g. permission denied): flag it broken
+    // rather than aborting the scan.
+    return { broken: true };
+  }
+  const resolved = safeStat(absPath);
+  return resolved?.isFile() ? { symlinkTarget } : { symlinkTarget, broken: true };
+}
+
+/** True for directories, including symlinks that resolve to directories. */
+export function isTraversableDir(entry: Dirent, absPath: string): boolean {
+  if (entry.isDirectory()) {
+    return true;
+  }
+  return entry.isSymbolicLink() && (safeStat(absPath)?.isDirectory() ?? false);
+}
+
+/** Sorted listing; an unreadable or missing directory contributes nothing. */
+export function sortedEntries(absDir: string): Dirent[] {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(absDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+
+/**
+ * Cycle-safe recursive walk. Directories are marked visited by real path, so
+ * symlink cycles and aliased trees terminate and each real directory is
+ * inventoried exactly once; `recurse` gates descent by directory name;
+ * `onFile` receives each file (or file symlink) with its POSIX-style path
+ * relative to the walk root.
+ */
+export function walk(
+  absDir: string,
+  relDir: string,
+  visited: Set<string>,
+  recurse: (dirName: string) => boolean,
+  onFile: (name: string, rel: string, info: FileInfo) => void,
+): void {
+  let real: string;
+  try {
+    real = realpathSync(absDir);
+  } catch {
+    return;
+  }
+  if (visited.has(real)) {
+    return;
+  }
+  visited.add(real);
+  for (const entry of sortedEntries(absDir)) {
+    const abs = join(absDir, entry.name);
+    const rel = relDir === "" ? entry.name : `${relDir}/${entry.name}`;
+    if (isTraversableDir(entry, abs)) {
+      if (recurse(entry.name)) {
+        walk(abs, rel, visited, recurse, onFile);
+      }
+    } else {
+      const info = fileInfoFromEntry(entry, abs);
+      if (info) {
+        onFile(entry.name, rel, info);
+      }
+    }
+  }
+}
+
+/**
+ * Final path segment, used as the machine-independent display name of probe
+ * paths. `win32.basename` handles both separators (POSIX `basename` would
+ * treat `C:\a\b` as a single segment), so probe paths from any OS work.
+ */
+export function lastSegment(path: string): string {
+  return win32.basename(path);
+}
+
+/** Deterministic code-unit ordering by path, then kind, then scope. */
+export function compareArtifacts(a: DetectedArtifact, b: DetectedArtifact): number {
+  if (a.path !== b.path) {
+    return a.path < b.path ? -1 : 1;
+  }
+  if (a.kind !== b.kind) {
+    return a.kind < b.kind ? -1 : 1;
+  }
+  return a.scope < b.scope ? -1 : a.scope > b.scope ? 1 : 0;
+}

--- a/lib/workspace-adapters/src/detect-test-utils.ts
+++ b/lib/workspace-adapters/src/detect-test-utils.ts
@@ -1,0 +1,144 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { assertGoldenCase, listGoldenCases } from "./golden.js";
+import type { AgentAdapter, DetectedArtifact, RepoContext } from "./types.js";
+
+/**
+ * Shared wiring for detector test suites (test-only; excluded from the
+ * package build). Extracted from the T1.1/T1.2 suites so T1.3+ detectors
+ * reuse the golden boilerplate, temp-repo factory, and symlink probe instead
+ * of copying them.
+ */
+
+/** Absolute path of this package's golden fixtures root. */
+export const fixturesRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../fixtures");
+
+/**
+ * Loads a case's `options.json` (sibling of `input-repo/`, so never part of
+ * the scanned tree); `{}` when absent. The options shape — and how relative
+ * paths inside it resolve against the case directory — is adapter-specific,
+ * so callers map the parsed value to a `RepoContext` themselves.
+ */
+export function loadCaseOptions<T>(caseDir: string): T {
+  const optionsPath = join(caseDir, "options.json");
+  return existsSync(optionsPath)
+    ? (JSON.parse(readFileSync(optionsPath, "utf8")) as T)
+    : ({} as T);
+}
+
+/**
+ * The golden `describe` block every detector suite ships: the ≥3-cases /
+ * negative-case acceptance check, the fixtures-declared-on-adapter check,
+ * and one byte-exact assertion per case. `contextFor` maps a case directory
+ * (holding the adapter-specific `options.json`) to the detector's context.
+ */
+export function describeDetectorGoldens(
+  adapter: AgentAdapter,
+  taskId: string,
+  contextFor: (caseDir: string, inputRepoDir: string) => RepoContext,
+): void {
+  describe(`${adapter.name} golden fixtures`, () => {
+    const goldenCases = listGoldenCases(fixturesRoot).filter(
+      (c) => c.adapter === adapter.name,
+    );
+
+    it(`ships at least 3 cases including the negative one (${taskId} AC)`, () => {
+      expect(goldenCases.length).toBeGreaterThanOrEqual(3);
+      expect(goldenCases.map((c) => c.name)).toContain("no-artifacts");
+    });
+
+    it("declares its fixtures on the adapter, matching the on-disk cases", () => {
+      expect(adapter.fixtures.map((f) => f.name)).toEqual(goldenCases.map((c) => c.name));
+    });
+
+    for (const goldenCase of goldenCases) {
+      it(`matches ${goldenCase.name} byte-exactly`, async () => {
+        await assertGoldenCase(goldenCase, (inputRepoDir) => [
+          {
+            path: "detected.json",
+            content: serialize(adapter.detect(contextFor(goldenCase.dir, inputRepoDir))),
+          },
+        ]);
+      });
+    }
+  });
+}
+
+function serialize(artifacts: readonly DetectedArtifact[]): string {
+  return `${JSON.stringify(artifacts, null, 2)}\n`;
+}
+
+/**
+ * Temp-directory factory whose directories are removed after each test.
+ * Registers its own `afterEach`, so call it at test-module top level.
+ */
+export function useTempDirs(): {
+  /** `mkdtemp` under the OS temp root, tracked for cleanup. */
+  makeDir(prefix: string): string;
+  /** Creates a temp repo populated with `files` and returns its root. */
+  makeRepo(prefix: string, files: Record<string, string>): string;
+} {
+  const tempDirs: string[] = [];
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+  const makeDir = (prefix: string): string => {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  };
+  return {
+    makeDir,
+    makeRepo(prefix, files) {
+      const root = makeDir(prefix);
+      for (const [path, content] of Object.entries(files)) {
+        mkdirSync(join(root, dirname(path)), { recursive: true });
+        writeFileSync(join(root, path), content);
+      }
+      return root;
+    },
+  };
+}
+
+/**
+ * File symlinks need Developer Mode or admin rights on Windows; directory
+ * links are created as junctions, which work unprivileged. Probed once per
+ * test module; gate symlink tests with `it.skipIf`.
+ */
+export const symlinkSupport: { file: boolean; directory: boolean } = (() => {
+  const dir = mkdtempSync(join(tmpdir(), "gitmesh-symlink-probe-"));
+  let file = false;
+  let directory = false;
+  try {
+    writeFileSync(join(dir, "target.txt"), "x");
+    try {
+      symlinkSync("target.txt", join(dir, "file-link"));
+      file = true;
+    } catch {
+      /* unsupported */
+    }
+    mkdirSync(join(dir, "target-dir"));
+    try {
+      symlinkSync(join(dir, "target-dir"), join(dir, "dir-link"), "junction");
+      directory = true;
+    } catch {
+      /* unsupported */
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  return { file, directory };
+})();

--- a/lib/workspace-adapters/src/types.ts
+++ b/lib/workspace-adapters/src/types.ts
@@ -1,6 +1,15 @@
 import type { WorkspaceIR } from "@gitmesh/workspace-core";
 
-/** Repository context passed to adapter operations. */
+/**
+ * Repository context passed to adapter operations.
+ *
+ * Probe-path overrides (`managedSettingsPaths`, `requirementsTomlPaths`, …)
+ * stay one named optional field per adapter rather than a generic probe map
+ * (decision, 2026-07-29, ahead of T1.3): the E1 backlog adds only a handful
+ * of detectors, and a named field keeps each override typed and documented
+ * where a string-keyed map could not. Revisit only if the field list
+ * outgrows the backlog.
+ */
 export interface RepoContext {
   /**
    * Absolute path to the repository root. Callers resolve the git root and
@@ -32,7 +41,11 @@ export interface RepoContext {
   requirementsTomlPaths?: readonly string[];
   /**
    * Environment consulted for machine-scoped hints (e.g. `CODEX_HOME`).
-   * Defaults to `process.env`; tests inject a fixed map.
+   * Defaults to `process.env`; tests inject a fixed map. Read only by the
+   * codex detector today; the claude-code detector's default
+   * managed-settings paths still read `process.env` directly (rewiring them
+   * through here would be a behavior change, so it rides with a future
+   * behavior task, not a refactor).
    */
   env?: Readonly<Record<string, string | undefined>>;
 }

--- a/lib/workspace-adapters/tsconfig.build.json
+++ b/lib/workspace-adapters/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/detect-test-utils.ts"]
 }


### PR DESCRIPTION
## chore: Extract detection mechanism

<!-- Use one of: feat, fix, docs, refactor, perf, test, build, breaking, chore -->
<!-- Example: feat: add ranked backlog generation -->


## Summary
Existing structure of detection logic increased redundancy because code for detection for every adapter of coding agent was implemented seperately. This PR tries to fix that
<!-- What does this PR do in 2–3 sentences? -->


## Related Issue

<!-- One of: Fixes / Resolves / Closes -->
Fixes #454 


## Type of Change

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [x] chore


## How Was This Tested?

- [x] Local run
- [x] Unit tests
- [x] Integration tests
- [x] Not tested (explain why)
