### PR TITLE
feat(workspace-core): implement cross-tool drift differ (Task T1.9)

### DIFF
--- a/.changeset/drift-differ.md
+++ b/.changeset/drift-differ.md
@@ -1,0 +1,5 @@
+---
+"@gitmesh/workspace-core": minor
+---
+
+Add the cross-tool instruction drift differ (pivot §10.4, T1.9): `computeDriftReport` takes detected instruction files, collapses paths resolving to the same logical document (symlink topology, e.g. `CLAUDE.md → AGENTS.md`) into one zero-drift document reported as a healthy `symlinkGroups` pattern, and computes per-pair block set diffs (multiset semantics) plus sequence diffs (`reordered` via longest common subsequence) over T1.8 normalized block hashes. `divergentBlocks` aggregates the "present in A, missing in B/C" view across all documents with sorted provenance. Pure data-in/data-out with deterministic ordering throughout; ships a seeded 3-way-drift fixture (with a real committed symlink) whose report is asserted byte-for-byte against `three-way-expected.json`.

--- a/lib/workspace-core/fixtures/drift/three-way-expected.json
+++ b/lib/workspace-core/fixtures/drift/three-way-expected.json
@@ -1,0 +1,237 @@
+{
+  "documents": [
+    {
+      "paths": [
+        ".cursor/rules/style.mdc"
+      ],
+      "label": ".cursor/rules/style.mdc",
+      "doc": {
+        "scope": {
+          "globs": [
+            "**/*.ts"
+          ],
+          "description": "Style rules"
+        },
+        "blocks": [
+          {
+            "kind": "heading",
+            "text": "# Project rules",
+            "hash": "3170bcf78a16dcb419f6a089e430f6f6cb220fca35e8a8b40ec4055441cb5cfc",
+            "managed": false
+          },
+          {
+            "kind": "list",
+            "text": "- Run tests before every commit.\n- Sign off commits with -s.",
+            "hash": "ae94fa06bafa2010af947c8953b02d92a01acdc9e5b3cdd7b6bb576292273ddf",
+            "managed": false
+          },
+          {
+            "kind": "paragraph",
+            "text": "Never commit secrets.",
+            "hash": "5f53ace965b8f860a98922dd77faa0342393e38545919383b174da45bee31cac",
+            "managed": false
+          }
+        ],
+        "hash": "6aa28fde0afdac9a9b984c9e3e675e686a27103b1f61c0f073d918c1bda05f97"
+      }
+    },
+    {
+      "paths": [
+        "AGENTS.md",
+        "CLAUDE.md"
+      ],
+      "label": "AGENTS.md",
+      "doc": {
+        "blocks": [
+          {
+            "kind": "heading",
+            "text": "# Project rules",
+            "hash": "3170bcf78a16dcb419f6a089e430f6f6cb220fca35e8a8b40ec4055441cb5cfc",
+            "managed": false
+          },
+          {
+            "kind": "paragraph",
+            "text": "Use pnpm for all installs.",
+            "hash": "a76abedac569cf9c4e7d2e498226a1d3cc73bb77375b568a3651717d26ab678e",
+            "managed": false
+          },
+          {
+            "kind": "list",
+            "text": "- Run tests before every commit.\n- Sign off commits with -s.",
+            "hash": "ae94fa06bafa2010af947c8953b02d92a01acdc9e5b3cdd7b6bb576292273ddf",
+            "managed": false
+          }
+        ],
+        "hash": "c1602201ac940f4e55f59e8ffca1fd2da3a8dc9ddfdaea694073fd15dbd40063"
+      }
+    },
+    {
+      "paths": [
+        "GEMINI.md"
+      ],
+      "label": "GEMINI.md",
+      "doc": {
+        "blocks": [
+          {
+            "kind": "heading",
+            "text": "# Project rules",
+            "hash": "3170bcf78a16dcb419f6a089e430f6f6cb220fca35e8a8b40ec4055441cb5cfc",
+            "managed": false
+          },
+          {
+            "kind": "paragraph",
+            "text": "Use pnpm for all installs.",
+            "hash": "a76abedac569cf9c4e7d2e498226a1d3cc73bb77375b568a3651717d26ab678e",
+            "managed": false
+          },
+          {
+            "kind": "paragraph",
+            "text": "Prefer tabs over spaces.",
+            "hash": "01c3727681055430f7d74b10c6d0e928850d332362c18bf5157b07943e015369",
+            "managed": false
+          }
+        ],
+        "hash": "7aed378f679050712d636a3a9d5b92d7c54094a713ab78fe0b17b06f8a433d98"
+      }
+    }
+  ],
+  "symlinkGroups": [
+    [
+      "AGENTS.md",
+      "CLAUDE.md"
+    ]
+  ],
+  "pairs": [
+    {
+      "a": ".cursor/rules/style.mdc",
+      "b": "AGENTS.md",
+      "onlyInA": [
+        {
+          "kind": "paragraph",
+          "text": "Never commit secrets.",
+          "hash": "5f53ace965b8f860a98922dd77faa0342393e38545919383b174da45bee31cac"
+        }
+      ],
+      "onlyInB": [
+        {
+          "kind": "paragraph",
+          "text": "Use pnpm for all installs.",
+          "hash": "a76abedac569cf9c4e7d2e498226a1d3cc73bb77375b568a3651717d26ab678e"
+        }
+      ],
+      "reordered": [],
+      "sharedCount": 2,
+      "identical": false
+    },
+    {
+      "a": ".cursor/rules/style.mdc",
+      "b": "GEMINI.md",
+      "onlyInA": [
+        {
+          "kind": "list",
+          "text": "- Run tests before every commit.\n- Sign off commits with -s.",
+          "hash": "ae94fa06bafa2010af947c8953b02d92a01acdc9e5b3cdd7b6bb576292273ddf"
+        },
+        {
+          "kind": "paragraph",
+          "text": "Never commit secrets.",
+          "hash": "5f53ace965b8f860a98922dd77faa0342393e38545919383b174da45bee31cac"
+        }
+      ],
+      "onlyInB": [
+        {
+          "kind": "paragraph",
+          "text": "Use pnpm for all installs.",
+          "hash": "a76abedac569cf9c4e7d2e498226a1d3cc73bb77375b568a3651717d26ab678e"
+        },
+        {
+          "kind": "paragraph",
+          "text": "Prefer tabs over spaces.",
+          "hash": "01c3727681055430f7d74b10c6d0e928850d332362c18bf5157b07943e015369"
+        }
+      ],
+      "reordered": [],
+      "sharedCount": 1,
+      "identical": false
+    },
+    {
+      "a": "AGENTS.md",
+      "b": "GEMINI.md",
+      "onlyInA": [
+        {
+          "kind": "list",
+          "text": "- Run tests before every commit.\n- Sign off commits with -s.",
+          "hash": "ae94fa06bafa2010af947c8953b02d92a01acdc9e5b3cdd7b6bb576292273ddf"
+        }
+      ],
+      "onlyInB": [
+        {
+          "kind": "paragraph",
+          "text": "Prefer tabs over spaces.",
+          "hash": "01c3727681055430f7d74b10c6d0e928850d332362c18bf5157b07943e015369"
+        }
+      ],
+      "reordered": [],
+      "sharedCount": 2,
+      "identical": false
+    }
+  ],
+  "divergentBlocks": [
+    {
+      "block": {
+        "kind": "list",
+        "text": "- Run tests before every commit.\n- Sign off commits with -s.",
+        "hash": "ae94fa06bafa2010af947c8953b02d92a01acdc9e5b3cdd7b6bb576292273ddf"
+      },
+      "presentIn": [
+        ".cursor/rules/style.mdc",
+        "AGENTS.md"
+      ],
+      "missingFrom": [
+        "GEMINI.md"
+      ]
+    },
+    {
+      "block": {
+        "kind": "paragraph",
+        "text": "Never commit secrets.",
+        "hash": "5f53ace965b8f860a98922dd77faa0342393e38545919383b174da45bee31cac"
+      },
+      "presentIn": [
+        ".cursor/rules/style.mdc"
+      ],
+      "missingFrom": [
+        "AGENTS.md",
+        "GEMINI.md"
+      ]
+    },
+    {
+      "block": {
+        "kind": "paragraph",
+        "text": "Use pnpm for all installs.",
+        "hash": "a76abedac569cf9c4e7d2e498226a1d3cc73bb77375b568a3651717d26ab678e"
+      },
+      "presentIn": [
+        "AGENTS.md",
+        "GEMINI.md"
+      ],
+      "missingFrom": [
+        ".cursor/rules/style.mdc"
+      ]
+    },
+    {
+      "block": {
+        "kind": "paragraph",
+        "text": "Prefer tabs over spaces.",
+        "hash": "01c3727681055430f7d74b10c6d0e928850d332362c18bf5157b07943e015369"
+      },
+      "presentIn": [
+        "GEMINI.md"
+      ],
+      "missingFrom": [
+        ".cursor/rules/style.mdc",
+        "AGENTS.md"
+      ]
+    }
+  ]
+}

--- a/lib/workspace-core/fixtures/drift/three-way/.cursor/rules/style.mdc
+++ b/lib/workspace-core/fixtures/drift/three-way/.cursor/rules/style.mdc
@@ -1,0 +1,10 @@
+---
+description: Style rules
+globs: "**/*.ts"
+---
+# Project rules
+
+- Run tests before every commit.
+- Sign off commits with -s.
+
+Never commit secrets.

--- a/lib/workspace-core/fixtures/drift/three-way/AGENTS.md
+++ b/lib/workspace-core/fixtures/drift/three-way/AGENTS.md
@@ -1,0 +1,6 @@
+# Project rules
+
+Use pnpm for all installs.
+
+- Run tests before every commit.
+- Sign off commits with -s.

--- a/lib/workspace-core/fixtures/drift/three-way/CLAUDE.md
+++ b/lib/workspace-core/fixtures/drift/three-way/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/lib/workspace-core/fixtures/drift/three-way/GEMINI.md
+++ b/lib/workspace-core/fixtures/drift/three-way/GEMINI.md
@@ -1,0 +1,5 @@
+# Project rules
+
+Use pnpm for all installs.
+
+Prefer tabs over spaces.

--- a/lib/workspace-core/src/drift/drift.test.ts
+++ b/lib/workspace-core/src/drift/drift.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import { computeDriftReport } from "./drift.js";
+
+const doc = (path: string, content: string, logicalPath?: string) => ({
+  path,
+  content,
+  ...(logicalPath === undefined ? {} : { logicalPath }),
+});
+
+describe("computeDriftReport - pairs", () => {
+  it("reports identical documents as identical despite formatting differences", () => {
+    const report = computeDriftReport([
+      doc("AGENTS.md", "# Rules\n\nUse pnpm.\n"),
+      doc("CLAUDE.md", "#  Rules \r\n\r\nUse   pnpm.\r\n"),
+    ]);
+    expect(report.pairs).toEqual([
+      {
+        a: "AGENTS.md",
+        b: "CLAUDE.md",
+        onlyInA: [],
+        onlyInB: [],
+        reordered: [],
+        sharedCount: 2,
+        identical: true,
+      },
+    ]);
+    expect(report.divergentBlocks).toEqual([]);
+  });
+
+  it("computes the block set diff per pair, in document order", () => {
+    const report = computeDriftReport([
+      doc("AGENTS.md", "# Rules\n\nUse pnpm.\n\n- run tests\n"),
+      doc("GEMINI.md", "# Rules\n\nPrefer tabs.\n"),
+    ]);
+    const [pair] = report.pairs;
+    expect(pair!.onlyInA.map((block) => block.text)).toEqual(["Use pnpm.", "- run tests"]);
+    expect(pair!.onlyInB.map((block) => block.text)).toEqual(["Prefer tabs."]);
+    expect(pair!.sharedCount).toBe(1);
+    expect(pair!.identical).toBe(false);
+  });
+
+  it("detects sequence drift among shared blocks", () => {
+    const report = computeDriftReport([
+      doc("AGENTS.md", "# A\n\n# B\n\n# C\n"),
+      doc("CLAUDE.md", "# B\n\n# A\n\n# C\n"),
+    ]);
+    const [pair] = report.pairs;
+    expect(pair!.onlyInA).toEqual([]);
+    expect(pair!.onlyInB).toEqual([]);
+    expect(pair!.reordered.map((block) => block.text)).toEqual(["# A"]);
+    expect(pair!.identical).toBe(false);
+  });
+
+  it("uses multiset semantics for duplicated blocks", () => {
+    const report = computeDriftReport([
+      doc("AGENTS.md", "same\n\nsame\n"),
+      doc("CLAUDE.md", "same\n"),
+    ]);
+    const [pair] = report.pairs;
+    expect(pair!.onlyInA.map((block) => block.text)).toEqual(["same"]);
+    expect(pair!.sharedCount).toBe(1);
+  });
+
+  it("emits every unordered pair in deterministic label order", () => {
+    const report = computeDriftReport([
+      doc("b.md", "x\n"),
+      doc("c.md", "x\n"),
+      doc("a.md", "x\n"),
+    ]);
+    expect(report.pairs.map((pair) => [pair.a, pair.b])).toEqual([
+      ["a.md", "b.md"],
+      ["a.md", "c.md"],
+      ["b.md", "c.md"],
+    ]);
+  });
+});
+
+describe("computeDriftReport - symlink topology", () => {
+  it("collapses paths sharing a logicalPath into one zero-drift document", () => {
+    const report = computeDriftReport([
+      doc("AGENTS.md", "# Rules\n", "/repo/AGENTS.md"),
+      doc("CLAUDE.md", "# Rules\n", "/repo/AGENTS.md"),
+      doc("GEMINI.md", "# Other\n", "/repo/GEMINI.md"),
+    ]);
+    expect(report.documents.map((document) => document.paths)).toEqual([
+      ["AGENTS.md", "CLAUDE.md"],
+      ["GEMINI.md"],
+    ]);
+    expect(report.symlinkGroups).toEqual([["AGENTS.md", "CLAUDE.md"]]);
+    // One logical pair, not three: the symlink never drifts against its target.
+    expect(report.pairs).toHaveLength(1);
+    expect(report.pairs[0]).toMatchObject({ a: "AGENTS.md", b: "GEMINI.md" });
+  });
+
+  it("keeps documents without logicalPath as their own logical document", () => {
+    const report = computeDriftReport([doc("a.md", "x\n"), doc("b.md", "x\n")]);
+    expect(report.symlinkGroups).toEqual([]);
+    expect(report.pairs).toHaveLength(1);
+  });
+});
+
+describe("computeDriftReport - divergent block aggregation", () => {
+  it('reports "present in A, missing in B/C" with sorted provenance', () => {
+    const report = computeDriftReport([
+      doc(".cursor/rules/style.mdc", "# Shared\n\n- cursor only rule\n"),
+      doc("AGENTS.md", "# Shared\n\nUse pnpm.\n"),
+      doc("CLAUDE.md", "# Shared\n\nUse pnpm.\n"),
+    ]);
+    expect(
+      report.divergentBlocks.map((entry) => ({
+        text: entry.block.text,
+        presentIn: entry.presentIn,
+        missingFrom: entry.missingFrom,
+      })),
+    ).toEqual([
+      {
+        text: "- cursor only rule",
+        presentIn: [".cursor/rules/style.mdc"],
+        missingFrom: ["AGENTS.md", "CLAUDE.md"],
+      },
+      {
+        text: "Use pnpm.",
+        presentIn: ["AGENTS.md", "CLAUDE.md"],
+        missingFrom: [".cursor/rules/style.mdc"],
+      },
+    ]);
+  });
+
+  it("excludes universal blocks and handles empty documents", () => {
+    const report = computeDriftReport([doc("a.md", "# Same\n"), doc("b.md", "")]);
+    expect(report.divergentBlocks).toEqual([
+      expect.objectContaining({ presentIn: ["a.md"], missingFrom: ["b.md"] }),
+    ]);
+    const empty = computeDriftReport([doc("a.md", ""), doc("b.md", "\n\n")]);
+    expect(empty.pairs[0]!.identical).toBe(true);
+    expect(empty.divergentBlocks).toEqual([]);
+  });
+});

--- a/lib/workspace-core/src/drift/drift.ts
+++ b/lib/workspace-core/src/drift/drift.ts
@@ -1,0 +1,255 @@
+/**
+ * Cross-tool instruction drift differ (pivot.md §10.4, T1.9).
+ *
+ * Cross-tool drift = set/sequence diff of normalized block hashes with
+ * provenance. Inputs are instruction documents already read by the caller
+ * (the doctor pipeline); each is normalized (T1.8) and compared:
+ *
+ * - Documents sharing a `logicalPath` (a symlink and its target, resolved
+ *   via `resolveLogicalPath`) collapse into ONE logical document - zero
+ *   drift by construction, reported in `symlinkGroups` as the healthy
+ *   pattern it is (§10.4, ADR-003).
+ * - Every unordered pair of logical documents gets a set diff (blocks only
+ *   in one side, multiset semantics so duplicated blocks count) and a
+ *   sequence diff (`reordered`: shared blocks whose relative order
+ *   differs, via longest-common-subsequence).
+ * - `divergentBlocks` aggregates across all documents: each block that is
+ *   missing somewhere, with `presentIn`/`missingFrom` - the
+ *   "present in A, missing in B/C" view.
+ *
+ * Pure data → data: no filesystem access, no wallclock, deterministic
+ * ordering everywhere (documents and pairs sorted by label, blocks in
+ * first-seen document order). Rendering prose/TTY/JSON output is T1.16's
+ * job; this module only computes the report.
+ */
+
+import {
+  normalizeInstructionMarkdown,
+  type BlockKind,
+  type NormalizedDocument,
+} from "../normalizer/index.js";
+
+/** One instruction file handed to the differ. */
+export interface DriftDocumentInput {
+  /** Stable display path (repo-relative POSIX, like detector output). */
+  path: string;
+  /** Raw file content. */
+  content: string;
+  /**
+   * Canonical identity from `resolveLogicalPath`; inputs sharing a value
+   * are one logical document (symlink topology). Omitted → the path is
+   * its own logical document.
+   */
+  logicalPath?: string;
+}
+
+/** A logical document in the report: one or more paths, one content. */
+export interface DriftDocument {
+  /** Sorted display paths; more than one means a symlink group. */
+  paths: string[];
+  /** `paths[0]`; the name used in pairs and presence lists. */
+  label: string;
+  /** Normalized content (blocks, hashes, scope). */
+  doc: NormalizedDocument;
+}
+
+/** Provenance-free reference to one normalized block. */
+export interface DriftBlockRef {
+  kind: BlockKind;
+  text: string;
+  hash: string;
+}
+
+/** Set/sequence diff between one pair of logical documents. */
+export interface PairDrift {
+  /** Labels of the compared documents; `a` sorts before `b`. */
+  a: string;
+  b: string;
+  /** Blocks (multiset) present in `a` but not `b`, in `a` order. */
+  onlyInA: DriftBlockRef[];
+  /** Blocks (multiset) present in `b` but not `a`, in `b` order. */
+  onlyInB: DriftBlockRef[];
+  /** Shared blocks whose relative order differs, in `a` order. */
+  reordered: DriftBlockRef[];
+  /** Number of shared blocks (multiset intersection size). */
+  sharedCount: number;
+  /** True when both sides carry the same blocks in the same order. */
+  identical: boolean;
+}
+
+/** Cross-document presence of one divergent block. */
+export interface BlockPresence {
+  block: DriftBlockRef;
+  /** Labels of documents containing the block, sorted. */
+  presentIn: string[];
+  /** Labels of documents missing the block, sorted. */
+  missingFrom: string[];
+}
+
+/** The full cross-tool drift report. */
+export interface DriftReport {
+  /** Logical documents, sorted by label. */
+  documents: DriftDocument[];
+  /** Path groups (≥2) collapsed by symlink topology - healthy, zero drift. */
+  symlinkGroups: string[][];
+  /** Every unordered pair of logical documents, lexicographic by labels. */
+  pairs: PairDrift[];
+  /** Blocks missing from at least one document, first-seen order. */
+  divergentBlocks: BlockPresence[];
+}
+
+/** Computes the cross-tool drift report for a set of instruction files. */
+export function computeDriftReport(inputs: readonly DriftDocumentInput[]): DriftReport {
+  const documents = groupLogicalDocuments(inputs);
+  const symlinkGroups = documents
+    .filter((document) => document.paths.length > 1)
+    .map((document) => document.paths);
+
+  const pairs: PairDrift[] = [];
+  for (let i = 0; i < documents.length; i++) {
+    for (let j = i + 1; j < documents.length; j++) {
+      pairs.push(diffPair(documents[i]!, documents[j]!));
+    }
+  }
+
+  return { documents, symlinkGroups, pairs, divergentBlocks: aggregatePresence(documents) };
+}
+
+/** Groups inputs by logical identity and normalizes each group once. */
+function groupLogicalDocuments(inputs: readonly DriftDocumentInput[]): DriftDocument[] {
+  const groups = new Map<string, { paths: Set<string>; content: string }>();
+  for (const input of inputs) {
+    // A path with no logical identity (e.g. an unresolvable file the caller
+    // still wants compared) stands alone under its own display path.
+    const key = input.logicalPath ?? `path:${input.path}`;
+    const group = groups.get(key);
+    if (group) {
+      group.paths.add(input.path);
+    } else {
+      groups.set(key, { paths: new Set([input.path]), content: input.content });
+    }
+  }
+  return [...groups.values()]
+    .map(({ paths, content }) => {
+      const sorted = [...paths].sort();
+      return {
+        paths: sorted,
+        label: sorted[0]!,
+        doc: normalizeInstructionMarkdown(content),
+      };
+    })
+    .sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0));
+}
+
+/** Set diff (multiset) + sequence diff for one document pair. */
+function diffPair(a: DriftDocument, b: DriftDocument): PairDrift {
+  const countsB = countByHash(b.doc.blocks);
+  const sharedA: DriftBlockRef[] = [];
+  const onlyInA: DriftBlockRef[] = [];
+  for (const block of a.doc.blocks) {
+    const remaining = countsB.get(block.hash) ?? 0;
+    if (remaining > 0) {
+      countsB.set(block.hash, remaining - 1);
+      sharedA.push(toRef(block));
+    } else {
+      onlyInA.push(toRef(block));
+    }
+  }
+
+  const countsA = countByHash(a.doc.blocks);
+  const sharedB: DriftBlockRef[] = [];
+  const onlyInB: DriftBlockRef[] = [];
+  for (const block of b.doc.blocks) {
+    const remaining = countsA.get(block.hash) ?? 0;
+    if (remaining > 0) {
+      countsA.set(block.hash, remaining - 1);
+      sharedB.push(toRef(block));
+    } else {
+      onlyInB.push(toRef(block));
+    }
+  }
+
+  const inSequence = lcsMembership(
+    sharedA.map((block) => block.hash),
+    sharedB.map((block) => block.hash),
+  );
+  const reordered = sharedA.filter((_, index) => !inSequence[index]);
+
+  return {
+    a: a.label,
+    b: b.label,
+    onlyInA,
+    onlyInB,
+    reordered,
+    sharedCount: sharedA.length,
+    identical: onlyInA.length === 0 && onlyInB.length === 0 && reordered.length === 0,
+  };
+}
+
+/** Blocks missing from at least one document, with presence provenance. */
+function aggregatePresence(documents: readonly DriftDocument[]): BlockPresence[] {
+  const seen = new Map<string, DriftBlockRef>();
+  for (const document of documents) {
+    for (const block of document.doc.blocks) {
+      if (!seen.has(block.hash)) {
+        seen.set(block.hash, toRef(block));
+      }
+    }
+  }
+  const result: BlockPresence[] = [];
+  for (const [hash, block] of seen) {
+    const presentIn: string[] = [];
+    const missingFrom: string[] = [];
+    for (const document of documents) {
+      const has = document.doc.blocks.some((candidate) => candidate.hash === hash);
+      (has ? presentIn : missingFrom).push(document.label);
+    }
+    if (missingFrom.length > 0) {
+      result.push({ block, presentIn, missingFrom });
+    }
+  }
+  return result;
+}
+
+/**
+ * Marks which elements of `a` belong to one deterministic longest common
+ * subsequence of `a` and `b`; elements outside it are "out of order".
+ */
+function lcsMembership(a: readonly string[], b: readonly string[]): boolean[] {
+  const dp: number[][] = Array.from({ length: a.length + 1 }, () =>
+    new Array<number>(b.length + 1).fill(0),
+  );
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      dp[i]![j] =
+        a[i] === b[j] ? dp[i + 1]![j + 1]! + 1 : Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!);
+    }
+  }
+  const member = new Array<boolean>(a.length).fill(false);
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      member[i] = true;
+      i++;
+      j++;
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+  return member;
+}
+
+function countByHash(blocks: readonly { hash: string }[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const block of blocks) {
+    counts.set(block.hash, (counts.get(block.hash) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function toRef(block: { kind: BlockKind; text: string; hash: string }): DriftBlockRef {
+  return { kind: block.kind, text: block.text, hash: block.hash };
+}

--- a/lib/workspace-core/src/drift/fixture.test.ts
+++ b/lib/workspace-core/src/drift/fixture.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { computeDriftReport, type DriftDocumentInput } from "./drift.js";
+import { resolveLogicalPath } from "../normalizer/index.js";
+
+/**
+ * Seeded 3-way-drift fixture (T1.9 AC): three logical documents - AGENTS.md
+ * (with CLAUDE.md symlinked to it), GEMINI.md, and a scoped
+ * `.cursor/rules/style.mdc` - with known seeded divergences. The computed
+ * report must match `expected.json` byte-for-byte: exactly the seeded
+ * drift, nothing more, nothing less.
+ */
+const FIXTURE_DIR = fileURLToPath(
+  new URL("../../fixtures/drift/three-way/", import.meta.url),
+);
+
+/** The instruction files of the fixture repo, as the doctor would feed them. */
+function readFixtureInputs(): DriftDocumentInput[] {
+  const paths = ["AGENTS.md", "CLAUDE.md", "GEMINI.md", ".cursor/rules/style.mdc"];
+  return paths.map((path) => {
+    const absolute = join(FIXTURE_DIR, path);
+    const input: DriftDocumentInput = {
+      path,
+      content: readFileSync(absolute, "utf8"),
+    };
+    const logicalPath = resolveLogicalPath(absolute);
+    if (logicalPath !== undefined) {
+      input.logicalPath = logicalPath;
+    }
+    return input;
+  });
+}
+
+describe("three-way drift fixture", () => {
+  it("is set up with a real CLAUDE.md → AGENTS.md symlink", () => {
+    expect(readdirSync(FIXTURE_DIR).sort()).toEqual([
+      ".cursor",
+      "AGENTS.md",
+      "CLAUDE.md",
+      "GEMINI.md",
+    ]);
+    expect(resolveLogicalPath(join(FIXTURE_DIR, "CLAUDE.md"))).toBe(
+      resolveLogicalPath(join(FIXTURE_DIR, "AGENTS.md")),
+    );
+  });
+
+  it("reports exactly the seeded drift, byte-for-byte", () => {
+    const report = computeDriftReport(readFixtureInputs());
+    const rendered = JSON.stringify(report, null, 2) + "\n";
+    const expected = readFileSync(join(FIXTURE_DIR, "..", "three-way-expected.json"), "utf8");
+    expect(rendered).toBe(expected);
+  });
+
+  it("collapses the symlink to zero drift and pins the seeded divergences", () => {
+    const report = computeDriftReport(readFixtureInputs());
+    expect(report.symlinkGroups).toEqual([["AGENTS.md", "CLAUDE.md"]]);
+    expect(report.pairs).toHaveLength(3);
+    expect(
+      report.divergentBlocks.map((entry) => ({
+        text: entry.block.text,
+        presentIn: entry.presentIn,
+        missingFrom: entry.missingFrom,
+      })),
+    ).toEqual([
+      {
+        text: "- Run tests before every commit.\n- Sign off commits with -s.",
+        presentIn: [".cursor/rules/style.mdc", "AGENTS.md"],
+        missingFrom: ["GEMINI.md"],
+      },
+      {
+        text: "Never commit secrets.",
+        presentIn: [".cursor/rules/style.mdc"],
+        missingFrom: ["AGENTS.md", "GEMINI.md"],
+      },
+      {
+        text: "Use pnpm for all installs.",
+        presentIn: ["AGENTS.md", "GEMINI.md"],
+        missingFrom: [".cursor/rules/style.mdc"],
+      },
+      {
+        text: "Prefer tabs over spaces.",
+        presentIn: ["GEMINI.md"],
+        missingFrom: [".cursor/rules/style.mdc", "AGENTS.md"],
+      },
+    ]);
+  });
+});

--- a/lib/workspace-core/src/drift/index.ts
+++ b/lib/workspace-core/src/drift/index.ts
@@ -1,0 +1,9 @@
+export {
+  computeDriftReport,
+  type DriftDocumentInput,
+  type DriftDocument,
+  type DriftBlockRef,
+  type PairDrift,
+  type BlockPresence,
+  type DriftReport,
+} from "./drift.js";

--- a/lib/workspace-core/src/index.ts
+++ b/lib/workspace-core/src/index.ts
@@ -13,3 +13,12 @@ export {
   type InstructionScope,
   type FrontmatterSplit,
 } from "./normalizer/index.js";
+export {
+  computeDriftReport,
+  type DriftDocumentInput,
+  type DriftDocument,
+  type DriftBlockRef,
+  type PairDrift,
+  type BlockPresence,
+  type DriftReport,
+} from "./drift/index.js";


### PR DESCRIPTION
Implements **T1.9** (pivot.md §12 / §10.4): the cross-tool instruction drift differ in `lib/workspace-core/src/drift/`, built on the T1.8 normalizer (#467).

Closes #462

## What it does

- **`computeDriftReport(inputs)`** — takes instruction files (display path, content, optional `logicalPath` from `resolveLogicalPath`) and computes §10.4's "set/sequence diff of block hashes with provenance":
  - **Symlink topology**: inputs sharing a logical path collapse into ONE logical document — a `CLAUDE.md → AGENTS.md` symlink is zero drift *by construction* (it never forms a pair against its target) and is reported in `symlinkGroups` as the healthy pattern (§10.4, ADR-003).
  - **Per-pair diffs** for every unordered pair of logical documents: `onlyInA`/`onlyInB` block set diffs with **multiset semantics** (a block duplicated in one file but not the other counts as drift), `sharedCount`, and a **sequence diff** — `reordered` lists shared blocks whose relative order differs, computed via a deterministic longest-common-subsequence.
  - **`divergentBlocks`** — the "present in A, missing in B/C" aggregation: every block missing from at least one document, with sorted `presentIn`/`missingFrom` provenance; universal blocks are excluded (they are not drift).
- **Seeded 3-way-drift fixture (the AC)**: `fixtures/drift/three-way/` holds AGENTS.md, a **real committed symlink** CLAUDE.md → AGENTS.md, GEMINI.md, and a scoped `.cursor/rules/style.mdc`, each with known seeded divergences. The test resolves the symlink with T1.8's `resolveLogicalPath` and asserts the full report **byte-for-byte** against `three-way-expected.json` — exactly the seeded blocks, nothing more — plus an explicit assertion listing each seeded divergence.
- 12 new tests (47 total in core): identical-under-formatting-dialects, set diff, sequence drift, multiset duplicates, deterministic pair ordering, symlink collapsing, aggregation, empty documents, fixture byte-exactness.

## Sanity check of the merged T1.8 state (as asked by the maintainer flow)

Before building on it I re-verified merged main locally: core 35/35, adapters 182/182, typecheck/build/lint clean, and stress-tested the normalizer with adversarial inputs (thematic breaks, setext headings, unclosed managed regions, fences inside lists, duplicated blocks). All behaviors are deterministic and consistent on both sides of a comparison — no fixes needed. One inherited, documented limitation: setext headings (`Title\n===`) normalize as paragraphs (T1.8 is ATX-only), so an ATX-vs-setext pair would report drift; no known agent emitter produces setext.

## Decisions worth flagging

1. **The differ is pure (no fs)**: symlink resolution happens at the call site via `resolveLogicalPath`, matching the detector contract (T1.1–T1.7 inventory symlinks literally; resolution is a comparison-time concern). The fixture test demonstrates the intended composition.
2. **Data-only report, no prose**: the issue's example wording ("Block present in CLAUDE.md missing in …") is representable directly from `divergentBlocks`; rendering prose/TTY/JSON/MD is T1.16's job, so this module deliberately emits structured data only.
3. **Managed blocks participate in cross-tool comparison**: §10.4 says managed content compares against expected emitter output — that comparison needs the emitters (E4) and lands with `check`; until then managed regions are gitmesh-emitted and identical across tools by construction, so including them adds no false positives. The `managed` flag stays available on `documents[].doc.blocks` for the future check pipeline.
4. **Scope globs are reported, not diffed**: each logical document carries its parsed `InstructionScope`; whether differing scopes on hash-equal rules count as drift is a doctor-rule question (GM011 territory), left out of T1.9.

Constraints honored: no server/db/network imports, deterministic byte-identical output, fixture includes negative signal (universal blocks excluded; symlink pair produces no drift).

## Testing

- `pnpm --filter @gitmesh/workspace-core test:run` — 47/47 pass
- `pnpm --filter @gitmesh/workspace-core typecheck && build` — clean
- `pnpm --filter @gitmesh/workspace-adapters test:run` — 182/182 pass
- ESLint (incl. T0.4 boundary rule) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)