### PR TITLE
feat(workspace-core): implement doctor report renderers (Task T1.16)

### DIFF
--- a/.changeset/doctor-renderers.md
+++ b/.changeset/doctor-renderers.md
@@ -1,0 +1,5 @@
+---
+"@gitmesh/workspace-core": minor
+---
+
+Add the `gitmesh doctor` report renderers (pivot §8.1 item 4, T1.16): a `DoctorReport` model (inventory with adapter provenance and manager labels, the T1.9 drift report, the T1.10 findings) rendered three ways - `renderDoctorTty` (inventory grouped by adapter, drift per document pair, findings grouped by severity, opt-in ANSI colors, 0–100 score), `renderDoctorJson` (versioned `schemaVersion: 1` schema, projected field by field so artifact content can never leak) and `renderDoctorMarkdown` (PR-comment layout with a collapsed inventory). The score starts at 100 and costs 20 per error, 5 per warning and 5 per divergent instruction pair; informational findings are free. Pure data → string with deterministic ordering; ships one file snapshot per mode plus a redaction guarantee across all three.

--- a/lib/workspace-core/src/index.ts
+++ b/lib/workspace-core/src/index.ts
@@ -38,3 +38,16 @@ export {
   type RuleContext,
   type RiskRule,
 } from "./risk/index.js";
+export {
+  summarizeDoctorReport,
+  renderDoctorTty,
+  renderDoctorJson,
+  renderDoctorMarkdown,
+  DOCTOR_JSON_SCHEMA_VERSION,
+  type DoctorArtifact,
+  type DoctorReport,
+  type DoctorSummary,
+  type DoctorTtyOptions,
+  type DoctorJson,
+  type DoctorJsonDocument,
+} from "./report/index.js";

--- a/lib/workspace-core/src/report/__snapshots__/doctor.json
+++ b/lib/workspace-core/src/report/__snapshots__/doctor.json
@@ -1,0 +1,270 @@
+{
+  "schemaVersion": 1,
+  "summary": {
+    "score": 55,
+    "artifacts": 9,
+    "adapters": 6,
+    "findings": {
+      "error": 1,
+      "warning": 2,
+      "info": 1
+    },
+    "driftingPairs": 3
+  },
+  "artifacts": [
+    {
+      "adapter": "antigravity",
+      "path": "GEMINI.md",
+      "kind": "instructions",
+      "scope": "project"
+    },
+    {
+      "adapter": "claude-code",
+      "path": ".claude/settings.json",
+      "kind": "settings",
+      "scope": "project"
+    },
+    {
+      "adapter": "claude-code",
+      "path": ".mcp.json",
+      "kind": "mcp-config",
+      "scope": "project"
+    },
+    {
+      "adapter": "claude-code",
+      "path": "CLAUDE.md",
+      "kind": "instructions",
+      "scope": "project",
+      "symlinkTarget": "AGENTS.md"
+    },
+    {
+      "adapter": "claude-code",
+      "path": "~/.claude/CLAUDE.md",
+      "kind": "instructions",
+      "scope": "user"
+    },
+    {
+      "adapter": "codex",
+      "path": "AGENTS.md",
+      "kind": "instructions",
+      "scope": "project"
+    },
+    {
+      "adapter": "cursor",
+      "path": ".cursor/rules/style.mdc",
+      "kind": "rule",
+      "scope": "project"
+    },
+    {
+      "adapter": "roo",
+      "path": ".roo/rules/old.md",
+      "kind": "rule",
+      "scope": "project",
+      "symlinkTarget": "../missing.md",
+      "broken": true
+    },
+    {
+      "adapter": "third-party-managers",
+      "path": ".ruler/ruler.toml",
+      "kind": "config",
+      "scope": "project",
+      "manager": "ruler"
+    }
+  ],
+  "drift": {
+    "documents": [
+      {
+        "label": ".cursor/rules/style.mdc",
+        "paths": [
+          ".cursor/rules/style.mdc"
+        ],
+        "blocks": 2
+      },
+      {
+        "label": "AGENTS.md",
+        "paths": [
+          "AGENTS.md",
+          "CLAUDE.md"
+        ],
+        "blocks": 3
+      },
+      {
+        "label": "GEMINI.md",
+        "paths": [
+          "GEMINI.md"
+        ],
+        "blocks": 4
+      }
+    ],
+    "symlinkGroups": [
+      [
+        "AGENTS.md",
+        "CLAUDE.md"
+      ]
+    ],
+    "pairs": [
+      {
+        "a": ".cursor/rules/style.mdc",
+        "b": "AGENTS.md",
+        "identical": false,
+        "sharedCount": 1,
+        "onlyInA": [
+          {
+            "kind": "paragraph",
+            "text": "Never commit secrets | tokens.",
+            "hash": "9933c0723bba45ba1473bda997d6dfd46eba7b7b4d2983d2614abc3f50878324"
+          }
+        ],
+        "onlyInB": [
+          {
+            "kind": "heading",
+            "text": "# Project rules",
+            "hash": "3170bcf78a16dcb419f6a089e430f6f6cb220fca35e8a8b40ec4055441cb5cfc"
+          },
+          {
+            "kind": "list",
+            "text": "- Run tests before every commit.\n- Sign off commits with -s.",
+            "hash": "ae94fa06bafa2010af947c8953b02d92a01acdc9e5b3cdd7b6bb576292273ddf"
+          }
+        ],
+        "reordered": []
+      },
+      {
+        "a": ".cursor/rules/style.mdc",
+        "b": "GEMINI.md",
+        "identical": false,
+        "sharedCount": 1,
+        "onlyInA": [
+          {
+            "kind": "paragraph",
+            "text": "Never commit secrets | tokens.",
+            "hash": "9933c0723bba45ba1473bda997d6dfd46eba7b7b4d2983d2614abc3f50878324"
+          }
+        ],
+        "onlyInB": [
+          {
+            "kind": "heading",
+            "text": "# Project rules",
+            "hash": "3170bcf78a16dcb419f6a089e430f6f6cb220fca35e8a8b40ec4055441cb5cfc"
+          },
+          {
+            "kind": "list",
+            "text": "- Run tests before every commit.\n- Sign off commits with -s.",
+            "hash": "ae94fa06bafa2010af947c8953b02d92a01acdc9e5b3cdd7b6bb576292273ddf"
+          },
+          {
+            "kind": "paragraph",
+            "text": "Prefer tabs over spaces.",
+            "hash": "01c3727681055430f7d74b10c6d0e928850d332362c18bf5157b07943e015369"
+          }
+        ],
+        "reordered": []
+      },
+      {
+        "a": "AGENTS.md",
+        "b": "GEMINI.md",
+        "identical": false,
+        "sharedCount": 3,
+        "onlyInA": [],
+        "onlyInB": [
+          {
+            "kind": "paragraph",
+            "text": "Prefer tabs over spaces.",
+            "hash": "01c3727681055430f7d74b10c6d0e928850d332362c18bf5157b07943e015369"
+          }
+        ],
+        "reordered": [
+          {
+            "kind": "paragraph",
+            "text": "Use pnpm for all installs.",
+            "hash": "a76abedac569cf9c4e7d2e498226a1d3cc73bb77375b568a3651717d26ab678e"
+          }
+        ]
+      }
+    ],
+    "divergentBlocks": [
+      {
+        "block": {
+          "kind": "paragraph",
+          "text": "Never commit secrets | tokens.",
+          "hash": "9933c0723bba45ba1473bda997d6dfd46eba7b7b4d2983d2614abc3f50878324"
+        },
+        "presentIn": [
+          ".cursor/rules/style.mdc"
+        ],
+        "missingFrom": [
+          "AGENTS.md",
+          "GEMINI.md"
+        ]
+      },
+      {
+        "block": {
+          "kind": "heading",
+          "text": "# Project rules",
+          "hash": "3170bcf78a16dcb419f6a089e430f6f6cb220fca35e8a8b40ec4055441cb5cfc"
+        },
+        "presentIn": [
+          "AGENTS.md",
+          "GEMINI.md"
+        ],
+        "missingFrom": [
+          ".cursor/rules/style.mdc"
+        ]
+      },
+      {
+        "block": {
+          "kind": "list",
+          "text": "- Run tests before every commit.\n- Sign off commits with -s.",
+          "hash": "ae94fa06bafa2010af947c8953b02d92a01acdc9e5b3cdd7b6bb576292273ddf"
+        },
+        "presentIn": [
+          "AGENTS.md",
+          "GEMINI.md"
+        ],
+        "missingFrom": [
+          ".cursor/rules/style.mdc"
+        ]
+      },
+      {
+        "block": {
+          "kind": "paragraph",
+          "text": "Prefer tabs over spaces.",
+          "hash": "01c3727681055430f7d74b10c6d0e928850d332362c18bf5157b07943e015369"
+        },
+        "presentIn": [
+          "GEMINI.md"
+        ],
+        "missingFrom": [
+          ".cursor/rules/style.mdc",
+          "AGENTS.md"
+        ]
+      }
+    ]
+  },
+  "findings": [
+    {
+      "ruleId": "GM001",
+      "severity": "error",
+      "message": "MCP server github sets GITHUB_TOKEN to a plaintext value (redacted)",
+      "path": ".mcp.json",
+      "adapter": "claude-code"
+    },
+    {
+      "ruleId": "GM002",
+      "severity": "warning",
+      "message": "No agent denies reads of .env files"
+    },
+    {
+      "ruleId": "GM008",
+      "severity": "info",
+      "message": "roo config present but no roo activity in history",
+      "adapter": "roo"
+    },
+    {
+      "ruleId": "GM010",
+      "severity": "warning",
+      "message": "CLAUDE.md is not bridged to AGENTS.md | add an @AGENTS.md shim",
+      "path": "CLAUDE.md"
+    }
+  ]
+}

--- a/lib/workspace-core/src/report/__snapshots__/doctor.md
+++ b/lib/workspace-core/src/report/__snapshots__/doctor.md
@@ -35,11 +35,11 @@ Divergent blocks:
 | antigravity | `GEMINI.md` | instructions |  |
 | claude-code | `.claude/settings.json` | settings |  |
 | claude-code | `.mcp.json` | mcp-config |  |
-| claude-code | `CLAUDE.md` | instructions | symlink -> AGENTS.md |
+| claude-code | `CLAUDE.md` | instructions | symlink -&gt; AGENTS.md |
 | claude-code | `~/.claude/CLAUDE.md` | instructions | user |
 | codex | `AGENTS.md` | instructions |  |
 | cursor | `.cursor/rules/style.mdc` | rule |  |
-| roo | `.roo/rules/old.md` | rule | symlink -> ../missing.md, broken |
+| roo | `.roo/rules/old.md` | rule | symlink -&gt; ../missing.md, broken |
 | third-party-managers | `.ruler/ruler.toml` | config | managed by ruler |
 
 </details>

--- a/lib/workspace-core/src/report/__snapshots__/doctor.md
+++ b/lib/workspace-core/src/report/__snapshots__/doctor.md
@@ -1,0 +1,45 @@
+## gitmesh doctor: 55/100
+
+9 artifacts across 6 adapters. 1 error, 2 warnings, 1 info. 3 divergent instruction pairs.
+
+### Findings
+
+| Severity | Rule | Location | Message |
+| --- | --- | --- | --- |
+| error | GM001 | `.mcp.json` (claude-code) | MCP server github sets GITHUB_TOKEN to a plaintext value (redacted) |
+| warning | GM002 |  | No agent denies reads of .env files |
+| warning | GM010 | `CLAUDE.md` | CLAUDE.md is not bridged to AGENTS.md \| add an @AGENTS.md shim |
+| info | GM008 | (roo) | roo config present but no roo activity in history |
+
+### Drift
+
+| Documents | Result |
+| --- | --- |
+| `AGENTS.md` = `CLAUDE.md` | symlink group, zero drift |
+| `.cursor/rules/style.mdc` vs `AGENTS.md` | 1 block only in .cursor/rules/style.mdc, 2 blocks only in AGENTS.md, 1 shared |
+| `.cursor/rules/style.mdc` vs `GEMINI.md` | 1 block only in .cursor/rules/style.mdc, 3 blocks only in GEMINI.md, 1 shared |
+| `AGENTS.md` vs `GEMINI.md` | 1 block only in GEMINI.md, 1 reordered, 3 shared |
+
+Divergent blocks:
+
+- "Never commit secrets \| tokens." in `.cursor/rules/style.mdc`; missing from `AGENTS.md`, `GEMINI.md`
+- "# Project rules" in `AGENTS.md`, `GEMINI.md`; missing from `.cursor/rules/style.mdc`
+- "- Run tests before every commit...." in `AGENTS.md`, `GEMINI.md`; missing from `.cursor/rules/style.mdc`
+- "Prefer tabs over spaces." in `GEMINI.md`; missing from `.cursor/rules/style.mdc`, `AGENTS.md`
+
+<details>
+<summary>Inventory (9 artifacts, 6 adapters)</summary>
+
+| Adapter | Path | Kind | Notes |
+| --- | --- | --- | --- |
+| antigravity | `GEMINI.md` | instructions |  |
+| claude-code | `.claude/settings.json` | settings |  |
+| claude-code | `.mcp.json` | mcp-config |  |
+| claude-code | `CLAUDE.md` | instructions | symlink -> AGENTS.md |
+| claude-code | `~/.claude/CLAUDE.md` | instructions | user |
+| codex | `AGENTS.md` | instructions |  |
+| cursor | `.cursor/rules/style.mdc` | rule |  |
+| roo | `.roo/rules/old.md` | rule | symlink -> ../missing.md, broken |
+| third-party-managers | `.ruler/ruler.toml` | config | managed by ruler |
+
+</details>

--- a/lib/workspace-core/src/report/__snapshots__/doctor.tty.txt
+++ b/lib/workspace-core/src/report/__snapshots__/doctor.tty.txt
@@ -1,0 +1,40 @@
+[1mgitmesh doctor[0m
+
+[1mInventory (9 artifacts, 6 adapters)[0m
+  [36mantigravity[0m
+    GEMINI.md  [2minstructions[0m
+  [36mclaude-code[0m
+    .claude/settings.json  [2msettings    [0m
+    .mcp.json              [2mmcp-config  [0m
+    CLAUDE.md              [2minstructions[0m  [2msymlink -> AGENTS.md[0m
+    ~/.claude/CLAUDE.md    [2minstructions[0m  [2muser[0m
+  [36mcodex[0m
+    AGENTS.md  [2minstructions[0m
+  [36mcursor[0m
+    .cursor/rules/style.mdc  [2mrule[0m
+  [36mroo[0m
+    .roo/rules/old.md  [2mrule[0m  [2msymlink -> ../missing.md, broken[0m
+  [36mthird-party-managers[0m
+    .ruler/ruler.toml  [2mconfig[0m  [2mmanaged by ruler[0m
+
+[1mDrift (3 instruction documents, 3 divergent pairs)[0m
+  AGENTS.md = CLAUDE.md  [32msymlink group, zero drift[0m
+  .cursor/rules/style.mdc vs AGENTS.md  [33m1 block only in .cursor/rules/style.mdc, 2 blocks only in AGENTS.md, 1 shared[0m
+  .cursor/rules/style.mdc vs GEMINI.md  [33m1 block only in .cursor/rules/style.mdc, 3 blocks only in GEMINI.md, 1 shared[0m
+  AGENTS.md vs GEMINI.md  [33m1 block only in GEMINI.md, 1 reordered, 3 shared[0m
+  divergent blocks
+    "Never commit secrets | tokens."  [2min .cursor/rules/style.mdc; missing from AGENTS.md, GEMINI.md[0m
+    "# Project rules"  [2min AGENTS.md, GEMINI.md; missing from .cursor/rules/style.mdc[0m
+    "- Run tests before every commit...."  [2min AGENTS.md, GEMINI.md; missing from .cursor/rules/style.mdc[0m
+    "Prefer tabs over spaces."  [2min GEMINI.md; missing from .cursor/rules/style.mdc, AGENTS.md[0m
+
+[1mFindings (1 error, 2 warnings, 1 info)[0m
+  [31merror[0m
+    [1mGM001[0m  .mcp.json (claude-code)  MCP server github sets GITHUB_TOKEN to a plaintext value (redacted)
+  [33mwarning[0m
+    [1mGM002[0m             No agent denies reads of .env files
+    [1mGM010[0m  CLAUDE.md  CLAUDE.md is not bridged to AGENTS.md | add an @AGENTS.md shim
+  [36minfo[0m
+    [1mGM008[0m  (roo)  roo config present but no roo activity in history
+
+[1mScore[0m [33m55/100[0m

--- a/lib/workspace-core/src/report/index.ts
+++ b/lib/workspace-core/src/report/index.ts
@@ -1,0 +1,14 @@
+export {
+  summarizeDoctorReport,
+  type DoctorArtifact,
+  type DoctorReport,
+  type DoctorSummary,
+} from "./report.js";
+export { renderDoctorTty, type DoctorTtyOptions } from "./tty.js";
+export {
+  renderDoctorJson,
+  DOCTOR_JSON_SCHEMA_VERSION,
+  type DoctorJson,
+  type DoctorJsonDocument,
+} from "./json.js";
+export { renderDoctorMarkdown } from "./markdown.js";

--- a/lib/workspace-core/src/report/json.ts
+++ b/lib/workspace-core/src/report/json.ts
@@ -1,0 +1,92 @@
+/**
+ * `--json` renderer: the stable, versioned machine-readable schema
+ * (consumed later by the check Action and the receipt bundle's
+ * `doctor.json`, §10.7). Every object is projected field by field so key
+ * order is fixed and nothing outside the schema (notably artifact
+ * `content`) can leak into the output.
+ */
+
+import type { BlockPresence, PairDrift } from "../drift/index.js";
+import type { RiskFinding } from "../risk/index.js";
+import {
+  groupArtifacts,
+  summarizeDoctorReport,
+  type DoctorArtifact,
+  type DoctorReport,
+  type DoctorSummary,
+} from "./report.js";
+
+/** Bump when a field changes meaning or disappears; additions are compatible. */
+export const DOCTOR_JSON_SCHEMA_VERSION = 1;
+
+export interface DoctorJsonDocument {
+  label: string;
+  paths: string[];
+  blocks: number;
+}
+
+export interface DoctorJson {
+  schemaVersion: typeof DOCTOR_JSON_SCHEMA_VERSION;
+  summary: DoctorSummary;
+  /** Sorted by adapter, then path. Exactly these fields; never content. */
+  artifacts: Pick<
+    DoctorArtifact,
+    "adapter" | "path" | "kind" | "scope" | "symlinkTarget" | "broken" | "manager"
+  >[];
+  drift: {
+    documents: DoctorJsonDocument[];
+    symlinkGroups: string[][];
+    pairs: PairDrift[];
+    divergentBlocks: BlockPresence[];
+  };
+  findings: RiskFinding[];
+}
+
+export function renderDoctorJson(report: DoctorReport): string {
+  const { drift } = report;
+  const json: DoctorJson = {
+    schemaVersion: DOCTOR_JSON_SCHEMA_VERSION,
+    summary: summarizeDoctorReport(report),
+    artifacts: groupArtifacts(report)
+      .flatMap(([, artifacts]) => artifacts)
+      .map(({ adapter, path, kind, scope, symlinkTarget, broken, manager }) => ({
+        adapter,
+        path,
+        kind,
+        scope,
+        symlinkTarget,
+        broken,
+        manager,
+      })),
+    drift: {
+      documents: drift.documents.map(({ label, paths, doc }) => ({
+        label,
+        paths,
+        blocks: doc.blocks.length,
+      })),
+      symlinkGroups: drift.symlinkGroups,
+      pairs: drift.pairs.map(({ a, b, identical, sharedCount, onlyInA, onlyInB, reordered }) => ({
+        a,
+        b,
+        identical,
+        sharedCount,
+        onlyInA,
+        onlyInB,
+        reordered,
+      })),
+      divergentBlocks: drift.divergentBlocks.map(({ block, presentIn, missingFrom }) => ({
+        block,
+        presentIn,
+        missingFrom,
+      })),
+    },
+    findings: report.findings.map(({ ruleId, severity, message, path, adapter }) => ({
+      ruleId,
+      severity,
+      message,
+      path,
+      adapter,
+    })),
+  };
+  return JSON.stringify(json, null, 2) + "\n";
+}

--- a/lib/workspace-core/src/report/json.ts
+++ b/lib/workspace-core/src/report/json.ts
@@ -10,6 +10,7 @@ import type { BlockPresence, PairDrift } from "../drift/index.js";
 import type { RiskFinding } from "../risk/index.js";
 import {
   groupArtifacts,
+  redactBlock,
   summarizeDoctorReport,
   type DoctorArtifact,
   type DoctorReport,
@@ -70,12 +71,12 @@ export function renderDoctorJson(report: DoctorReport): string {
         b,
         identical,
         sharedCount,
-        onlyInA,
-        onlyInB,
-        reordered,
+        onlyInA: onlyInA.map(redactBlock),
+        onlyInB: onlyInB.map(redactBlock),
+        reordered: reordered.map(redactBlock),
       })),
       divergentBlocks: drift.divergentBlocks.map(({ block, presentIn, missingFrom }) => ({
-        block,
+        block: redactBlock(block),
         presentIn,
         missingFrom,
       })),

--- a/lib/workspace-core/src/report/markdown.ts
+++ b/lib/workspace-core/src/report/markdown.ts
@@ -1,0 +1,95 @@
+/**
+ * `--md` renderer, shaped for a PR comment: score headline, findings table
+ * first, drift table, inventory collapsed in `<details>`.
+ */
+
+import {
+  artifactNotes,
+  blockPreview,
+  describeFindingCounts,
+  describePair,
+  findingsOf,
+  groupArtifacts,
+  plural,
+  SEVERITIES,
+  summarizeDoctorReport,
+  type DoctorReport,
+} from "./report.js";
+
+/** Table-cell safe text: no pipes, no line breaks. */
+const cell = (text: string): string => text.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+const code = (text: string): string => `\`${cell(text)}\``;
+
+export function renderDoctorMarkdown(report: DoctorReport): string {
+  const summary = summarizeDoctorReport(report);
+  const lines: string[] = [
+    `## gitmesh doctor: ${summary.score}/100`,
+    "",
+    `${plural(summary.artifacts, "artifact")} across ${plural(summary.adapters, "adapter")}. ` +
+      `${describeFindingCounts(summary)}. ${plural(summary.driftingPairs, "divergent instruction pair")}.`,
+    "",
+    "### Findings",
+    "",
+  ];
+
+  if (report.findings.length === 0) {
+    lines.push("No findings.", "");
+  } else {
+    lines.push("| Severity | Rule | Location | Message |", "| --- | --- | --- | --- |");
+    for (const severity of SEVERITIES) {
+      for (const finding of findingsOf(report, severity)) {
+        const location = [finding.path && code(finding.path), finding.adapter && `(${finding.adapter})`]
+          .filter(Boolean)
+          .join(" ");
+        lines.push(`| ${severity} | ${finding.ruleId} | ${location} | ${cell(finding.message)} |`);
+      }
+    }
+    lines.push("");
+  }
+
+  const { drift } = report;
+  lines.push("### Drift", "");
+  if (drift.pairs.length === 0 && drift.symlinkGroups.length === 0) {
+    lines.push("Fewer than two instruction documents, nothing to compare.", "");
+  } else {
+    lines.push("| Documents | Result |", "| --- | --- |");
+    for (const group of drift.symlinkGroups) {
+      lines.push(`| ${group.map(code).join(" = ")} | symlink group, zero drift |`);
+    }
+    for (const pair of drift.pairs) {
+      lines.push(`| ${code(pair.a)} vs ${code(pair.b)} | ${cell(describePair(pair))} |`);
+    }
+    lines.push("");
+  }
+  if (drift.divergentBlocks.length > 0) {
+    lines.push("Divergent blocks:", "");
+    for (const { block, presentIn, missingFrom } of drift.divergentBlocks) {
+      lines.push(
+        `- ${cell(JSON.stringify(blockPreview(block.text)))} in ${presentIn.map(code).join(", ")}; ` +
+          `missing from ${missingFrom.map(code).join(", ")}`,
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    "<details>",
+    `<summary>Inventory (${plural(summary.artifacts, "artifact")}, ${plural(summary.adapters, "adapter")})</summary>`,
+    "",
+  );
+  if (summary.artifacts === 0) {
+    lines.push("No agent artifacts found.", "");
+  } else {
+    lines.push("| Adapter | Path | Kind | Notes |", "| --- | --- | --- | --- |");
+    for (const [adapter, artifacts] of groupArtifacts(report)) {
+      for (const artifact of artifacts) {
+        lines.push(
+          `| ${adapter} | ${code(artifact.path)} | ${cell(artifact.kind)} | ${cell(artifactNotes(artifact).join(", "))} |`,
+        );
+      }
+    }
+    lines.push("");
+  }
+  lines.push("</details>");
+  return lines.join("\n") + "\n";
+}

--- a/lib/workspace-core/src/report/markdown.ts
+++ b/lib/workspace-core/src/report/markdown.ts
@@ -11,14 +11,17 @@ import {
   findingsOf,
   groupArtifacts,
   plural,
+  redactBlock,
   SEVERITIES,
   summarizeDoctorReport,
   type DoctorReport,
 } from "./report.js";
 
-/** Table-cell safe text: no pipes, no line breaks. */
-const cell = (text: string): string => text.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
-const code = (text: string): string => `\`${cell(text)}\``;
+/** Table-cell safe text: no pipes, no line breaks; code spans are literal, prose also escapes HTML. */
+const span = (text: string): string => text.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+const cell = (text: string): string =>
+  span(text).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+const code = (text: string): string => `\`${span(text)}\``;
 
 export function renderDoctorMarkdown(report: DoctorReport): string {
   const summary = summarizeDoctorReport(report);
@@ -65,7 +68,7 @@ export function renderDoctorMarkdown(report: DoctorReport): string {
     lines.push("Divergent blocks:", "");
     for (const { block, presentIn, missingFrom } of drift.divergentBlocks) {
       lines.push(
-        `- ${cell(JSON.stringify(blockPreview(block.text)))} in ${presentIn.map(code).join(", ")}; ` +
+        `- ${cell(JSON.stringify(blockPreview(redactBlock(block).text)))} in ${presentIn.map(code).join(", ")}; ` +
           `missing from ${missingFrom.map(code).join(", ")}`,
       );
     }

--- a/lib/workspace-core/src/report/report.test.ts
+++ b/lib/workspace-core/src/report/report.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import { computeDriftReport } from "../drift/index.js";
+import type { RiskFinding } from "../risk/index.js";
+import { summarizeDoctorReport, type DoctorArtifact, type DoctorReport } from "./report.js";
+import { renderDoctorTty } from "./tty.js";
+import { renderDoctorJson } from "./json.js";
+import { renderDoctorMarkdown } from "./markdown.js";
+
+/** A value that must never appear in any output mode (hard rule 5). */
+const SECRET = "ghp_FAKE0123456789abcdefghijklmnopqrstu";
+
+const AGENTS_MD = `# Project rules
+
+Use pnpm for all installs.
+
+- Run tests before every commit.
+- Sign off commits with -s.
+`;
+const GEMINI_MD = `# Project rules
+
+- Run tests before every commit.
+- Sign off commits with -s.
+
+Use pnpm for all installs.
+
+Prefer tabs over spaces.
+`;
+const STYLE_MDC = `---
+description: Style rules
+globs: "**/*.ts"
+---
+Never commit secrets | tokens.
+
+Use pnpm for all installs.
+`;
+
+const artifact = (
+  adapter: string,
+  path: string,
+  kind: string,
+  extra: Partial<DoctorArtifact> = {},
+): DoctorArtifact => ({ adapter, path, kind, scope: "project", ...extra });
+
+/** Kitchen sink: six adapters, a symlink, a broken link, a manager, drift, every severity. */
+const REPORT: DoctorReport = {
+  artifacts: [
+    artifact("codex", "AGENTS.md", "instructions", { content: AGENTS_MD }),
+    artifact("claude-code", "CLAUDE.md", "instructions", { symlinkTarget: "AGENTS.md" }),
+    artifact("claude-code", ".mcp.json", "mcp-config", {
+      content: `{"mcpServers":{"github":{"env":{"GITHUB_TOKEN":"${SECRET}"}}}}`,
+    }),
+    artifact("claude-code", ".claude/settings.json", "settings"),
+    artifact("claude-code", "~/.claude/CLAUDE.md", "instructions", { scope: "user" }),
+    artifact("cursor", ".cursor/rules/style.mdc", "rule", { content: STYLE_MDC }),
+    artifact("antigravity", "GEMINI.md", "instructions", { content: GEMINI_MD }),
+    artifact("roo", ".roo/rules/old.md", "rule", { symlinkTarget: "../missing.md", broken: true }),
+    artifact("third-party-managers", ".ruler/ruler.toml", "config", { manager: "ruler" }),
+  ],
+  drift: computeDriftReport([
+    { path: "AGENTS.md", content: AGENTS_MD, logicalPath: "/repo/AGENTS.md" },
+    { path: "CLAUDE.md", content: AGENTS_MD, logicalPath: "/repo/AGENTS.md" },
+    { path: "GEMINI.md", content: GEMINI_MD },
+    { path: ".cursor/rules/style.mdc", content: STYLE_MDC },
+  ]),
+  findings: [
+    {
+      ruleId: "GM001",
+      severity: "error",
+      message: "MCP server github sets GITHUB_TOKEN to a plaintext value (redacted)",
+      path: ".mcp.json",
+      adapter: "claude-code",
+    },
+    { ruleId: "GM002", severity: "warning", message: "No agent denies reads of .env files" },
+    {
+      ruleId: "GM008",
+      severity: "info",
+      message: "roo config present but no roo activity in history",
+      adapter: "roo",
+    },
+    {
+      ruleId: "GM010",
+      severity: "warning",
+      message: "CLAUDE.md is not bridged to AGENTS.md | add an @AGENTS.md shim",
+      path: "CLAUDE.md",
+    },
+  ],
+};
+
+const EMPTY: DoctorReport = { artifacts: [], drift: computeDriftReport([]), findings: [] };
+
+const RENDERERS = {
+  tty: (report: DoctorReport) => renderDoctorTty(report, { color: true }),
+  json: renderDoctorJson,
+  md: renderDoctorMarkdown,
+};
+
+describe("doctor renderers - snapshots", () => {
+  it("renders the TTY report (grouped, colored, scored)", async () => {
+    await expect(RENDERERS.tty(REPORT)).toMatchFileSnapshot("./__snapshots__/doctor.tty.txt");
+  });
+
+  it("renders the --json report (schema v1)", async () => {
+    await expect(RENDERERS.json(REPORT)).toMatchFileSnapshot("./__snapshots__/doctor.json");
+  });
+
+  it("renders the --md report", async () => {
+    await expect(RENDERERS.md(REPORT)).toMatchFileSnapshot("./__snapshots__/doctor.md");
+  });
+});
+
+describe("doctor renderers - guarantees", () => {
+  it.each(Object.entries(RENDERERS))("%s never emits artifact content", (_name, render) => {
+    expect(render(REPORT)).not.toContain(SECRET);
+    expect(render(REPORT)).not.toContain("ghp_");
+  });
+
+  it("colors only decorate: plain output is the colored output without escapes", () => {
+    const ESC = String.fromCharCode(27);
+    const colored = renderDoctorTty(REPORT, { color: true });
+    expect(colored).toContain(`${ESC}[31m`);
+    expect(colored.replace(new RegExp(`${ESC}\\[\\d+m`, "g"), "")).toBe(renderDoctorTty(REPORT));
+  });
+
+  it("scores 100 minus 20/error, 5/warning, 5/divergent pair; info is free; clamped at 0", () => {
+    expect(summarizeDoctorReport(REPORT)).toEqual({
+      score: 100 - 20 - 10 - 15,
+      artifacts: 9,
+      adapters: 6,
+      findings: { error: 1, warning: 2, info: 1 },
+      driftingPairs: 3,
+    });
+    const errors: RiskFinding[] = Array.from({ length: 6 }, (_, i) => ({
+      ruleId: "GM003",
+      severity: "error",
+      message: `bypass ${i}`,
+    }));
+    expect(summarizeDoctorReport({ ...EMPTY, findings: errors }).score).toBe(0);
+    expect(summarizeDoctorReport(EMPTY).score).toBe(100);
+  });
+
+  it("renders an empty workspace in every mode", () => {
+    expect(renderDoctorTty(EMPTY)).toContain("no agent artifacts found");
+    expect(renderDoctorTty(EMPTY)).toContain("no findings");
+    expect(renderDoctorMarkdown(EMPTY)).toContain("No findings.");
+    expect(JSON.parse(renderDoctorJson(EMPTY))).toMatchObject({
+      schemaVersion: 1,
+      summary: { score: 100 },
+    });
+  });
+
+  it("is deterministic and ends with a single newline in every mode", () => {
+    for (const render of Object.values(RENDERERS)) {
+      const output = render(REPORT);
+      expect(render(REPORT)).toBe(output);
+      expect(output.endsWith("\n")).toBe(true);
+      expect(output.endsWith("\n\n")).toBe(false);
+    }
+  });
+});

--- a/lib/workspace-core/src/report/report.test.ts
+++ b/lib/workspace-core/src/report/report.test.ts
@@ -115,6 +115,21 @@ describe("doctor renderers - guarantees", () => {
     expect(render(REPORT)).not.toContain("ghp_");
   });
 
+  it("redacts GM001-detected secrets in drift block text in every mode", () => {
+    const token = `ghp_${"Ab1".repeat(12)}`;
+    const report: DoctorReport = {
+      ...EMPTY,
+      drift: computeDriftReport([
+        { path: "AGENTS.md", content: `Deploy with ${token} and ship.\n` },
+        { path: "GEMINI.md", content: "Ship.\n" },
+      ]),
+    };
+    for (const render of Object.values(RENDERERS)) {
+      expect(render(report)).not.toContain(token);
+      expect(render(report)).toContain("[redacted GitHub token]");
+    }
+  });
+
   it("colors only decorate: plain output is the colored output without escapes", () => {
     const ESC = String.fromCharCode(27);
     const colored = renderDoctorTty(REPORT, { color: true });

--- a/lib/workspace-core/src/report/report.ts
+++ b/lib/workspace-core/src/report/report.ts
@@ -8,13 +8,16 @@
  * label), the T1.9 drift report and the T1.10 findings. The three renderers
  * (`tty`, `json`, `markdown`) turn it into text. Pure data → string: no
  * filesystem, no wallclock, deterministic ordering, and artifact `content`
- * never reaches any output mode (hard rule 5).
+ * never reaches any output mode (hard rule 5); drift block text passes
+ * through GM001's scanner first, so a token pasted into an instruction
+ * file is redacted in every mode too.
  *
  * Score: 100 minus 20 per error, 5 per warning, 5 per pair of instruction
  * documents that differ; `info` findings never cost points. Clamped at 0.
  */
 
-import type { DriftReport, PairDrift } from "../drift/index.js";
+import type { DriftBlockRef, DriftReport, PairDrift } from "../drift/index.js";
+import { scanForSecrets } from "../risk/gm001.js";
 import type { RiskArtifact, RiskFinding, RiskSeverity } from "../risk/index.js";
 
 /** An inventoried artifact plus its third-party manager, when one owns it. */
@@ -113,6 +116,15 @@ export function blockPreview(text: string): string {
   const firstLine = text.split("\n", 1)[0] ?? "";
   const cut = firstLine.length > 60 || firstLine.length < text.length;
   return `${firstLine.slice(0, 60)}${cut ? "..." : ""}`;
+}
+
+/** A block safe to print: lines GM001 flags are replaced; the hash still identifies it. */
+export function redactBlock(block: DriftBlockRef): DriftBlockRef {
+  const hits = scanForSecrets(block.text);
+  if (hits.length === 0) return block;
+  const lines = block.text.split("\n");
+  for (const { line, reason } of hits) lines[line - 1] = `[redacted ${reason}]`;
+  return { kind: block.kind, text: lines.join("\n"), hash: block.hash };
 }
 
 export function plural(count: number, noun: string): string {

--- a/lib/workspace-core/src/report/report.ts
+++ b/lib/workspace-core/src/report/report.ts
@@ -1,0 +1,131 @@
+/**
+ * Doctor report model, score and shared formatting (pivot.md §8.1 item 4,
+ * T1.16).
+ *
+ * `DoctorReport` is what one `gitmesh doctor` run assembles before any
+ * output: the inventory (detector artifacts with adapter provenance and
+ * pre-read content - the risk engine's own input, plus the T1.7 manager
+ * label), the T1.9 drift report and the T1.10 findings. The three renderers
+ * (`tty`, `json`, `markdown`) turn it into text. Pure data → string: no
+ * filesystem, no wallclock, deterministic ordering, and artifact `content`
+ * never reaches any output mode (hard rule 5).
+ *
+ * Score: 100 minus 20 per error, 5 per warning, 5 per pair of instruction
+ * documents that differ; `info` findings never cost points. Clamped at 0.
+ */
+
+import type { DriftReport, PairDrift } from "../drift/index.js";
+import type { RiskArtifact, RiskFinding, RiskSeverity } from "../risk/index.js";
+
+/** An inventoried artifact plus its third-party manager, when one owns it. */
+export interface DoctorArtifact extends RiskArtifact {
+  /** Manager reported by the T1.7 detector, e.g. `"ruler"`; informational. */
+  manager?: string;
+}
+
+/** Everything one `gitmesh doctor` run produces, before rendering. */
+export interface DoctorReport {
+  artifacts: readonly DoctorArtifact[];
+  drift: DriftReport;
+  findings: readonly RiskFinding[];
+}
+
+/** Headline numbers every renderer prints. */
+export interface DoctorSummary {
+  /** 0–100 health score. */
+  score: number;
+  artifacts: number;
+  adapters: number;
+  findings: Record<RiskSeverity, number>;
+  driftingPairs: number;
+}
+
+/** Severities in display order: most severe first. */
+export const SEVERITIES: readonly RiskSeverity[] = ["error", "warning", "info"];
+
+const PENALTY: Record<RiskSeverity, number> = { error: 20, warning: 5, info: 0 };
+const DRIFT_PENALTY = 5;
+
+export function summarizeDoctorReport(report: DoctorReport): DoctorSummary {
+  const findings: Record<RiskSeverity, number> = { error: 0, warning: 0, info: 0 };
+  for (const finding of report.findings) findings[finding.severity] += 1;
+  const driftingPairs = report.drift.pairs.filter((pair) => !pair.identical).length;
+  const penalty =
+    SEVERITIES.reduce((sum, severity) => sum + findings[severity] * PENALTY[severity], 0) +
+    driftingPairs * DRIFT_PENALTY;
+  return {
+    score: Math.max(0, 100 - penalty),
+    artifacts: report.artifacts.length,
+    adapters: new Set(report.artifacts.map((artifact) => artifact.adapter)).size,
+    findings,
+    driftingPairs,
+  };
+}
+
+/** Artifacts grouped by adapter; adapters and paths in code-point order. */
+export function groupArtifacts(
+  report: DoctorReport,
+): Array<[adapter: string, artifacts: DoctorArtifact[]]> {
+  const groups = new Map<string, DoctorArtifact[]>();
+  for (const artifact of report.artifacts) {
+    const list = groups.get(artifact.adapter);
+    if (list) list.push(artifact);
+    else groups.set(artifact.adapter, [artifact]);
+  }
+  return [...groups.entries()]
+    .sort(([a], [b]) => compareStrings(a, b))
+    .map(([adapter, list]) => [adapter, list.sort((a, b) => compareStrings(a.path, b.path))]);
+}
+
+/** Informational annotations shown after an artifact's path and kind. */
+export function artifactNotes(artifact: DoctorArtifact): string[] {
+  const notes: string[] = [];
+  if (artifact.scope !== "project") notes.push(artifact.scope);
+  if (artifact.symlinkTarget !== undefined) notes.push(`symlink -> ${artifact.symlinkTarget}`);
+  if (artifact.broken) notes.push("broken");
+  if (artifact.manager !== undefined) notes.push(`managed by ${artifact.manager}`);
+  return notes;
+}
+
+/** Findings of one severity, in engine order (rule id, path, adapter, message). */
+export function findingsOf(report: DoctorReport, severity: RiskSeverity): RiskFinding[] {
+  return report.findings.filter((finding) => finding.severity === severity);
+}
+
+/** `path (adapter)`, either part optional; empty for workspace-wide findings. */
+export function findingLocation(finding: RiskFinding): string {
+  return [finding.path, finding.adapter && `(${finding.adapter})`].filter(Boolean).join(" ");
+}
+
+/** One-line result of a document pair, e.g. `2 blocks only in A, 3 shared`. */
+export function describePair(pair: PairDrift): string {
+  if (pair.identical) return "identical";
+  const parts: string[] = [];
+  if (pair.onlyInA.length) parts.push(`${plural(pair.onlyInA.length, "block")} only in ${pair.a}`);
+  if (pair.onlyInB.length) parts.push(`${plural(pair.onlyInB.length, "block")} only in ${pair.b}`);
+  if (pair.reordered.length) parts.push(`${pair.reordered.length} reordered`);
+  parts.push(`${pair.sharedCount} shared`);
+  return parts.join(", ");
+}
+
+/** First line of a block, at most 60 characters, `...` when cut. */
+export function blockPreview(text: string): string {
+  const firstLine = text.split("\n", 1)[0] ?? "";
+  const cut = firstLine.length > 60 || firstLine.length < text.length;
+  return `${firstLine.slice(0, 60)}${cut ? "..." : ""}`;
+}
+
+export function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/** `1 error, 2 warnings, 1 info` (info has no plural). */
+export function describeFindingCounts(summary: DoctorSummary): string {
+  return SEVERITIES.map((severity) =>
+    severity === "info" ? `${summary.findings.info} info` : plural(summary.findings[severity], severity),
+  ).join(", ");
+}
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/lib/workspace-core/src/report/tty.ts
+++ b/lib/workspace-core/src/report/tty.ts
@@ -15,6 +15,7 @@ import {
   findingsOf,
   groupArtifacts,
   plural,
+  redactBlock,
   SEVERITIES,
   summarizeDoctorReport,
   type DoctorReport,
@@ -95,7 +96,7 @@ export function renderDoctorTty(report: DoctorReport, options: DoctorTtyOptions 
     lines.push("  divergent blocks");
     for (const { block, presentIn, missingFrom } of drift.divergentBlocks) {
       lines.push(
-        `    ${JSON.stringify(blockPreview(block.text))}  ` +
+        `    ${JSON.stringify(blockPreview(redactBlock(block).text))}  ` +
           p.dim(`in ${presentIn.join(", ")}; missing from ${missingFrom.join(", ")}`),
       );
     }

--- a/lib/workspace-core/src/report/tty.ts
+++ b/lib/workspace-core/src/report/tty.ts
@@ -1,0 +1,124 @@
+/**
+ * Human TTY renderer: inventory grouped by adapter, drift per document
+ * pair, findings grouped by severity, 0–100 score last so it is what the
+ * user sees after a long report scrolls. Colors are opt-in ANSI so piped
+ * output and snapshots stay clean by default.
+ */
+
+import type { RiskSeverity } from "../risk/index.js";
+import {
+  artifactNotes,
+  blockPreview,
+  describeFindingCounts,
+  describePair,
+  findingLocation,
+  findingsOf,
+  groupArtifacts,
+  plural,
+  SEVERITIES,
+  summarizeDoctorReport,
+  type DoctorReport,
+} from "./report.js";
+
+export interface DoctorTtyOptions {
+  /** Emit ANSI colors; off by default. The CLI enables it for a real TTY. */
+  color?: boolean;
+}
+
+type Paint = (text: string) => string;
+type Palette = Record<"bold" | "dim" | "red" | "yellow" | "green" | "cyan", Paint>;
+
+const ESC = String.fromCharCode(27);
+const ansi =
+  (code: number): Paint =>
+  (text) =>
+    `${ESC}[${code}m${text}${ESC}[0m`;
+const plain: Paint = (text) => text;
+
+const COLOR: Palette = {
+  bold: ansi(1),
+  dim: ansi(2),
+  red: ansi(31),
+  green: ansi(32),
+  yellow: ansi(33),
+  cyan: ansi(36),
+};
+const PLAIN: Palette = { bold: plain, dim: plain, red: plain, green: plain, yellow: plain, cyan: plain };
+
+const SEVERITY_COLOR: Record<RiskSeverity, keyof Palette> = {
+  error: "red",
+  warning: "yellow",
+  info: "cyan",
+};
+
+export function renderDoctorTty(report: DoctorReport, options: DoctorTtyOptions = {}): string {
+  const p = options.color ? COLOR : PLAIN;
+  const summary = summarizeDoctorReport(report);
+  const lines: string[] = [p.bold("gitmesh doctor"), ""];
+
+  lines.push(
+    p.bold(`Inventory (${plural(summary.artifacts, "artifact")}, ${plural(summary.adapters, "adapter")})`),
+  );
+  if (summary.artifacts === 0) lines.push(p.dim("  no agent artifacts found"));
+  for (const [adapter, artifacts] of groupArtifacts(report)) {
+    lines.push(`  ${p.cyan(adapter)}`);
+    const pathWidth = Math.max(...artifacts.map((artifact) => artifact.path.length));
+    const kindWidth = Math.max(...artifacts.map((artifact) => artifact.kind.length));
+    for (const artifact of artifacts) {
+      const notes = artifactNotes(artifact).join(", ");
+      lines.push(
+        `    ${artifact.path.padEnd(pathWidth)}  ${p.dim(artifact.kind.padEnd(kindWidth))}` +
+          (notes ? `  ${p.dim(notes)}` : ""),
+      );
+    }
+  }
+  lines.push("");
+
+  const { drift } = report;
+  lines.push(
+    p.bold(
+      `Drift (${plural(drift.documents.length, "instruction document")}, ` +
+        `${plural(summary.driftingPairs, "divergent pair")})`,
+    ),
+  );
+  if (drift.pairs.length === 0 && drift.symlinkGroups.length === 0) {
+    lines.push(p.dim("  fewer than two instruction documents, nothing to compare"));
+  }
+  for (const group of drift.symlinkGroups) {
+    lines.push(`  ${group.join(" = ")}  ${p.green("symlink group, zero drift")}`);
+  }
+  for (const pair of drift.pairs) {
+    const result = pair.identical ? p.green("identical") : p.yellow(describePair(pair));
+    lines.push(`  ${pair.a} vs ${pair.b}  ${result}`);
+  }
+  if (drift.divergentBlocks.length > 0) {
+    lines.push("  divergent blocks");
+    for (const { block, presentIn, missingFrom } of drift.divergentBlocks) {
+      lines.push(
+        `    ${JSON.stringify(blockPreview(block.text))}  ` +
+          p.dim(`in ${presentIn.join(", ")}; missing from ${missingFrom.join(", ")}`),
+      );
+    }
+  }
+  lines.push("");
+
+  lines.push(
+    p.bold(`Findings (${report.findings.length === 0 ? "none" : describeFindingCounts(summary)})`),
+  );
+  if (report.findings.length === 0) lines.push(p.green("  no findings"));
+  for (const severity of SEVERITIES) {
+    const group = findingsOf(report, severity);
+    if (group.length === 0) continue;
+    lines.push(`  ${p[SEVERITY_COLOR[severity]](severity)}`);
+    const width = Math.max(...group.map((finding) => findingLocation(finding).length));
+    for (const finding of group) {
+      const location = width > 0 ? `${findingLocation(finding).padEnd(width)}  ` : "";
+      lines.push(`    ${p.bold(finding.ruleId)}  ${location}${finding.message}`);
+    }
+  }
+  lines.push("");
+
+  const scorePaint = summary.score >= 80 ? p.green : summary.score >= 50 ? p.yellow : p.red;
+  lines.push(`${p.bold("Score")} ${scorePaint(`${summary.score}/100`)}`);
+  return lines.join("\n") + "\n";
+}


### PR DESCRIPTION
## PR Title

feat(workspace-core): implement doctor report renderers (Task T1.16)

## Summary

Implements pivot §12 T1.16: the three `gitmesh doctor` renderers, in `lib/workspace-core/src/report/`. A `DoctorReport` (inventory with adapter provenance and the T1.7 `manager` label, the T1.9 drift report, the T1.10 findings) renders as a grouped, colored TTY report with a 0–100 score, a versioned `--json` schema (`schemaVersion: 1`), and a `--md` layout for PR comments. Pure data → string with deterministic ordering; artifact content never reaches any output mode (hard rule 5).

## Related Issue

Task T1.16 in `doc/pivot/pivot.md` §12 (no tracking issue). Follows #474 (T1.15).

## Type of Change

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] build
- [ ] breaking
- [ ] chore

## Decisions

- **Score formula.** The pivot only specifies "0–100". I chose: 100 minus 20 per error, 5 per warning, 5 per divergent instruction-document pair; `info` findings cost nothing; clamped at 0. The weights are two constants in `report.ts`, so retuning is a one-line change.
- **Renderers only, no CLI wiring.** The renderers are pure functions in core; the `gitmesh doctor` command still prints "not implemented". The pipeline (detect → read → drift → rules → render) and the `--json` / `--md` flags belong with T1.17, where exit codes, `--fail-on`, and the fs-write / network spies test that command end to end.
- **Grouping.** TTY groups the inventory by adapter and findings by severity (error → warning → info, engine order within a group); the score prints last so it is what stays on screen after a long report. `--md` puts findings first and collapses the inventory in `<details>`.
- **Colors are opt-in** (`{ color: true }`), hand-rolled ANSI with no new dependency, so piped output and snapshots are plain by default. The TTY snapshot is the colored output; a test proves the plain output equals the colored output with escapes stripped.
- **JSON schema.** Every object is projected field by field (an explicit `Pick`), so key order is fixed and later `RiskArtifact` fields (`executable`, `tracked`, `ignored`, `content`) do not change the schema until deliberately added. Drift documents carry label, paths and block count; pairs and divergent blocks carry the T1.9 block text and hash.
- **`DoctorArtifact extends RiskArtifact` plus `manager?`**, so one inventory array feeds both `runRiskRules` and the renderers. `manager` stays off `RiskArtifact` to leave the engine untouched.
- **Drift block text is redacted** (review follow-up). Block previews in TTY/`--md` and block text in `--json` pass through GM001's `scanForSecrets`; any flagged line is replaced by `[redacted <reason>]` while the block hash keeps its identity. Closes the gap Copilot pointed at for a token pasted into an instruction file.
- **`--md` escapes HTML** (`&`, `<`, `>`) in prose cells so a `<placeholder>` in a message is not swallowed by GitHub's sanitizer; code spans stay literal.
- **Drift wording.** Symlink groups render as "symlink group, zero drift" (the healthy pattern, §10.4); block previews show the first line, at most 60 characters.

## How Was This Tested?

- [x] Local run
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested (explain why)

Notes:

In `lib/workspace-core`: 21 test files / 297 tests pass, `tsc --noEmit`, `pnpm lint` and `pnpm check:tokens` are clean. New tests: the three file snapshots required by the AC (`__snapshots__/doctor.tty.txt`, `doctor.json`, `doctor.md`), a redaction guarantee (a fake token placed in artifact content is absent from every mode), colored-equals-plain-when-stripped, score arithmetic and clamping, empty-workspace rendering, and determinism with a single trailing newline.

## Security Check

- [x] No secrets or credentials committed (the test fixture's `ghp_FAKE…` value is proven absent from every output mode)

## Screenshots / Demos (if UI or UX)

See `lib/workspace-core/src/report/__snapshots__/doctor.tty.txt` (colored TTY) and `doctor.md` (PR-comment layout).

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Tests updated/added where needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCteVkzZQjm6NPoxcQzuLA
